### PR TITLE
fix: add hotfix to display the silvi data for ayyoweca project

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,10 @@ const remotePatterns = [
     protocol: "https" as const,
     hostname: "gainforest-transparency-dashboard.s3.us-east-1.amazonaws.com",
   },
+  {
+    protocol: "https" as const,
+    hostname: "*",
+  },
 ].filter((pattern) => pattern !== null);
 
 const nextConfig: NextConfig = {

--- a/src/app/(map-routes)/_components/ProjectOverlay/store/ayyoweca-uganda.ts
+++ b/src/app/(map-routes)/_components/ProjectOverlay/store/ayyoweca-uganda.ts
@@ -1,0 +1,96 @@
+import { NormalizedTreeFeature } from "./types";
+
+export type GFTreeProperties = {
+  id: string;
+  date_planted?: string;
+  measurements_in_cm?: {
+    height?: number;
+    diameter?: number;
+    date_measured?: string;
+  };
+  taxonomy?: {
+    common_name?: string;
+    class?: string;
+    order?: string;
+    family?: string;
+    kingdom?: string;
+    genus?: string;
+    species?: string;
+  };
+  notes?: {
+    title: string;
+    description: string;
+    data?: {
+      [key: string]: string;
+    };
+  };
+  media_sources?: {
+    images?: Array<{
+      type: "leaf" | "bark" | "trunk" | "entire_specimen";
+      value: string;
+    }>;
+    videos?: Array<string>;
+    audios?: Array<string>;
+  };
+};
+
+export type GFTreeFeature = {
+  type: "Feature";
+  geometry: {
+    type: "Point";
+    coordinates: [number, number];
+  };
+  properties: GFTreeProperties;
+};
+
+export const convertFromGFTreeFeatureToNormalizedTreeFeature = (
+  feature: GFTreeFeature
+): NormalizedTreeFeature => {
+  return {
+    id: Number(feature.properties.id),
+    type: "Feature",
+    geometry: {
+      type: "Point",
+      coordinates: feature.geometry.coordinates,
+    },
+    properties: {
+      type: "measured-tree",
+      lat: feature.geometry.coordinates[1],
+      lon: feature.geometry.coordinates[0],
+      height: feature.properties.measurements_in_cm?.height
+        ? feature.properties.measurements_in_cm.height.toString()
+        : undefined,
+      Height: feature.properties.measurements_in_cm?.height
+        ? feature.properties.measurements_in_cm.height.toString()
+        : undefined,
+      diameter: feature.properties.measurements_in_cm?.diameter
+        ? feature.properties.measurements_in_cm.diameter.toString()
+        : undefined,
+      DBH: feature.properties.measurements_in_cm?.diameter
+        ? feature.properties.measurements_in_cm.diameter.toString()
+        : undefined,
+      species: feature.properties.taxonomy?.species ?? "",
+      dateMeasured: feature.properties.measurements_in_cm?.date_measured
+        ? new Date(
+            feature.properties.measurements_in_cm.date_measured
+          ).toLocaleDateString("en-GB")
+        : undefined,
+      dateOfMeasurement: feature.properties.measurements_in_cm?.date_measured
+        ? new Date(
+            feature.properties.measurements_in_cm.date_measured
+          ).toLocaleDateString("en-GB")
+        : undefined,
+      datePlanted: feature.properties.date_planted,
+      "FCD-tree_records-tree_time": feature.properties.date_planted,
+      "FCD-tree_records-tree_photo":
+        feature.properties.media_sources?.images?.[0]?.value,
+      ID: feature.properties.id,
+      awsUrl: feature.properties.media_sources?.images?.[0]?.value ?? "",
+      koboUrl: feature.properties.media_sources?.images?.[0]?.value ?? "",
+      leafAwsUrl: feature.properties.media_sources?.images?.[0]?.value ?? "",
+      leafKoboUrl: feature.properties.media_sources?.images?.[0]?.value ?? "",
+      barkAwsUrl: feature.properties.media_sources?.images?.[0]?.value ?? "",
+      barkKoboUrl: feature.properties.media_sources?.images?.[0]?.value ?? "",
+    },
+  };
+};

--- a/src/app/(map-routes)/_components/ProjectOverlay/store/types.ts
+++ b/src/app/(map-routes)/_components/ProjectOverlay/store/types.ts
@@ -78,7 +78,7 @@ export type TreeFeatureProperties = {
   lon: number;
   Height?: string;
   height?: string;
-  diameter: string;
+  diameter?: string;
   species: string;
   dateMeasured?: string;
   dateOfMeasurement?: string;

--- a/src/app/api/auth/options.ts
+++ b/src/app/api/auth/options.ts
@@ -105,4 +105,11 @@ export const authOptions: NextAuthOptions = {
       return session;
     },
   },
+  logger: {
+    error: (code, ...message) => {
+      if (code !== "CLIENT_FETCH_ERROR") {
+        console.error(code, message);
+      }
+    },
+  },
 };


### PR DESCRIPTION
# Changes:
1. Add an exception rule to the particular project, Ayyoweca Uganda to be able to show the silvi data after conversion to the normalized data.
![telegram-cloud-photo-size-5-6323181351913768305-y](https://github.com/user-attachments/assets/dd08491a-a8c9-4e73-a77d-76b1bb9cf497)
