### PR TITLE
feat: display common name when species is not available

### DIFF
--- a/src/app/(map-routes)/_components/HoveredTreeOverlay/index.tsx
+++ b/src/app/(map-routes)/_components/HoveredTreeOverlay/index.tsx
@@ -50,9 +50,19 @@ const HoveredTreeOverlay = () => {
               <div className="flex flex-col gap-1 items-start">
                 <span className="bg-muted/70 backdrop-blur-lg text-muted-foreground text-sm px-3 py-1 rounded-full flex items-center gap-2">
                   <Leaf size={16} />
-                  <span>Species</span>
+                  <span>
+                    {hoveredTree.treeSpecies
+                      ? "Species"
+                      : hoveredTree.treeCommonName
+                      ? "Common Name"
+                      : "Species"}
+                  </span>
                 </span>
-                <h1 className="text-xl font-bold">{hoveredTree.treeName}</h1>
+                <h1 className="text-xl font-bold">
+                  {hoveredTree.treeSpecies ??
+                    hoveredTree.treeCommonName ??
+                    "Unknown"}
+                </h1>
               </div>
               <div className="flex items-center justify-stretch gap-2">
                 <div className="flex-1 flex flex-col bg-muted rounded-xl p-2 gap-1">
@@ -121,7 +131,9 @@ const HoveredTreeOverlay = () => {
                 </div>
               </div>
               <span className="font-bold text-xs text-center p-1 leading-tight text-balance">
-                {hoveredTree.treeName}
+                {hoveredTree.treeSpecies ??
+                  hoveredTree.treeCommonName ??
+                  "Unknown"}
               </span>
             </button>
           </UIBase>

--- a/src/app/(map-routes)/_components/HoveredTreeOverlay/store.ts
+++ b/src/app/(map-routes)/_components/HoveredTreeOverlay/store.ts
@@ -2,7 +2,8 @@ import { create } from "zustand";
 
 export type HoveredTreeOverlayState = {
   treeInformation: {
-    treeName: string;
+    treeSpecies?: string;
+    treeCommonName?: string;
     treeHeight: string;
     treeDBH: string;
     treePhotos: string[];

--- a/src/app/(map-routes)/_components/Map/sources-and-layers/measured-trees.ts
+++ b/src/app/(map-routes)/_components/Map/sources-and-layers/measured-trees.ts
@@ -115,7 +115,7 @@ export const getTreeSpeciesName = (tree: TreeFeature["properties"]) => {
   } else if (tree?.species) {
     return tree?.species;
   } else {
-    return "unknown";
+    return undefined;
   }
 };
 

--- a/src/app/(map-routes)/_components/Map/utils.ts
+++ b/src/app/(map-routes)/_components/Map/utils.ts
@@ -16,6 +16,7 @@ import { addProjectMarkersSourceAndLayer } from "./sources-and-layers/project-ma
 import { ProjectSitePoints } from "./sources-and-layers/types";
 import { NormalizedTreeFeature } from "../ProjectOverlay/store/types";
 import { addLandcoverSourceAndLayer } from "./sources-and-layers/historical-satellite";
+import { HoveredTreeOverlayState } from "../HoveredTreeOverlay/store";
 
 export const spinGlobe = (map: Map, spinEnabled: boolean) => {
   const secondsPerRevolution = 120;
@@ -131,7 +132,7 @@ export const addProjectMarkerHandlers = (
 export const getTreeInformation = (
   e: MapMouseEvent,
   activeProjectId: string
-) => {
+): HoveredTreeOverlayState["treeInformation"] | null => {
   const features = e?.features;
   if (!features || features.length === 0) return null;
 
@@ -145,7 +146,8 @@ export const getTreeInformation = (
 
   if (!hoveredTreeFeature) return null;
 
-  const treeName = getTreeSpeciesName(hoveredTreeFeature.properties);
+  const treeSpecies = getTreeSpeciesName(hoveredTreeFeature.properties);
+  const treeCommonName = hoveredTreeFeature.properties?.commonName;
   const treeHeight = getTreeHeight(hoveredTreeFeature.properties);
   const treeDBH = getTreeDBH(hoveredTreeFeature.properties);
   const dateOfMeasurement = getTreeDateOfMeasurement(
@@ -165,9 +167,11 @@ export const getTreeInformation = (
     activeProjectId,
     treeID
   );
+  console.log(treeSpecies, treeCommonName);
 
   return {
-    treeName,
+    treeSpecies,
+    treeCommonName,
     treeHeight,
     treeDBH,
     treePhotos,

--- a/src/app/(map-routes)/_components/ProjectOverlay/store/ayyoweca-uganda.ts
+++ b/src/app/(map-routes)/_components/ProjectOverlay/store/ayyoweca-uganda.ts
@@ -70,6 +70,7 @@ export const convertFromGFTreeFeatureToNormalizedTreeFeature = (
         ? feature.properties.measurements_in_cm.diameter.toString()
         : undefined,
       species: feature.properties.taxonomy?.species ?? "",
+      commonName: feature.properties.taxonomy?.common_name ?? "",
       dateMeasured: feature.properties.measurements_in_cm?.date_measured
         ? new Date(
             feature.properties.measurements_in_cm.date_measured

--- a/src/app/(map-routes)/_components/ProjectOverlay/store/types.ts
+++ b/src/app/(map-routes)/_components/ProjectOverlay/store/types.ts
@@ -80,6 +80,7 @@ export type TreeFeatureProperties = {
   height?: string;
   diameter?: string;
   species: string;
+  commonName?: string;
   dateMeasured?: string;
   dateOfMeasurement?: string;
   datePlanted?: string;

--- a/src/app/(map-routes)/_components/ProjectOverlay/store/utils.ts
+++ b/src/app/(map-routes)/_components/ProjectOverlay/store/utils.ts
@@ -125,7 +125,8 @@ export const fetchMeasuredTreesShapefile = async (
           ...feature,
           properties: {
             ...feature.properties,
-            species: getTreeSpeciesName(feature.properties).trim(),
+            species:
+              getTreeSpeciesName(feature.properties)?.trim() ?? "Unknown",
             type: "measured-tree",
           },
           id: index,


### PR DESCRIPTION
# Changes
Display common name when species name is not availabe to display in the hovered tree overlay.

<img width="277" alt="image" src="https://github.com/user-attachments/assets/4eb34f53-fd62-40d2-9694-1685d783dda8" />
