### PR TITLE
Run homepage E2E on atproto-dev pushes

### DIFF
--- a/.github/workflows/e2e-homepage.yml
+++ b/.github/workflows/e2e-homepage.yml
@@ -1,6 +1,9 @@
 name: Homepage E2E
 
 on:
+  push:
+    branches:
+      - atproto-dev
   pull_request:
     branches:
       - atproto-dev

--- a/.github/workflows/e2e-homepage.yml
+++ b/.github/workflows/e2e-homepage.yml
@@ -13,6 +13,9 @@ jobs:
   homepage-e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      COOKIE_SECRET: e2e-cookie-secret-at-least-32-characters-long
+      NEXT_PUBLIC_MAPBOXGL_ACCESSTOKEN: ${{ secrets.MAPBOX_PUBLIC_TOKEN }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- run the homepage E2E workflow on pushes to atproto-dev in addition to pull requests
- keep manual workflow_dispatch support unchanged

## Testing
- pre-commit lint hook
