### PR TITLE
test: add homepage error-state e2e coverage

### DIFF
--- a/e2e/features/error-states.feature
+++ b/e2e/features/error-states.feature
@@ -1,16 +1,20 @@
-Feature: Error states
+Feature: Failure and empty states
 
   Scenario: Project info fails to load
     Given the fixture project page is open with a failing project info endpoint
-    Then the project error message is visible
+    Then the project error state is visible
 
   Scenario: Community members fail to load
     Given the fixture project page is open on the community view with a failing members endpoint
-    Then the community error message is visible
+    Then the community error state is visible
 
   Scenario: Biodiversity observations fail to load
     Given the fixture project page is open on the biodiversity observations view with a failing measured trees endpoint
-    Then the biodiversity error message is visible
+    Then the biodiversity observations error state is visible
+
+  Scenario: Biodiversity predictions fail to load
+    Given the fixture project page is open on the biodiversity predictions view with a failing predictions endpoint
+    Then the biodiversity predictions error state is visible
 
   Scenario: Search returns no results
     Given the homepage is open

--- a/e2e/features/error-states.feature
+++ b/e2e/features/error-states.feature
@@ -1,0 +1,18 @@
+Feature: Error states
+
+  Scenario: Project info fails to load
+    Given the fixture project page is open with a failing project info endpoint
+    Then the project error message is visible
+
+  Scenario: Community members fail to load
+    Given the fixture project page is open on the community view with a failing members endpoint
+    Then the community error message is visible
+
+  Scenario: Biodiversity observations fail to load
+    Given the fixture project page is open on the biodiversity observations view with a failing measured trees endpoint
+    Then the biodiversity error message is visible
+
+  Scenario: Search returns no results
+    Given the homepage is open
+    When the visitor searches for "zzznoresultsxyz"
+    Then the search empty state is visible

--- a/e2e/step-definitions/error.steps.ts
+++ b/e2e/step-definitions/error.steps.ts
@@ -12,6 +12,17 @@ import type { AppWorld } from "../support/world.js";
 
 const ERROR_UI_TIMEOUT = 15_000;
 
+const expectErrorMessage = async (
+  world: AppWorld,
+  text: string | RegExp = "Something went wrong...",
+) => {
+  const errorMessage = getPage(world).getByTestId("error-message");
+  await expect(errorMessage).toBeVisible({
+    timeout: ERROR_UI_TIMEOUT,
+  });
+  await expect(errorMessage).toContainText(text);
+};
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -85,27 +96,53 @@ Given(
 // Then steps — error state assertions
 // ---------------------------------------------------------------------------
 
-Then("the project error message is visible", async function (this: AppWorld) {
-  await expect(getPage(this).getByTestId("error-message")).toBeVisible({
-    timeout: ERROR_UI_TIMEOUT,
-  });
+Then("the project error state is visible", async function (this: AppWorld) {
+  const page = getPage(this);
+  await expect(page.getByTestId("project-overlay")).toBeVisible();
+  await expectErrorMessage(this, /Failed to load project\./);
+  await expect(page.getByTestId("error-message")).toContainText(
+    "Please check URL and retry.",
+  );
 });
 
-Then("the community error message is visible", async function (this: AppWorld) {
-  await expect(getPage(this).getByTestId("error-message")).toBeVisible({
-    timeout: ERROR_UI_TIMEOUT,
-  });
+Then("the community error state is visible", async function (this: AppWorld) {
+  const page = getPage(this);
+  await expect(page.getByTestId("project-overlay")).toBeVisible();
+  await expect(page.getByTestId("community-panel")).toBeVisible();
+  await expectErrorMessage(this);
 });
 
 Then(
-  "the biodiversity error message is visible",
+  "the biodiversity observations error state is visible",
   async function (this: AppWorld) {
-    await expect(getPage(this).getByTestId("error-message")).toBeVisible({
-      timeout: ERROR_UI_TIMEOUT,
-    });
+    const page = getPage(this);
+    await expect(page.getByTestId("project-overlay")).toBeVisible();
+    await expect(page.getByTestId("biodiversity-panel")).toBeVisible();
+    await expect(page.getByTestId("biodiversity-observations")).toBeVisible();
+    await expectErrorMessage(this);
+  },
+);
+
+Then(
+  "the biodiversity predictions error state is visible",
+  async function (this: AppWorld) {
+    const page = getPage(this);
+    await expect(page.getByTestId("project-overlay")).toBeVisible();
+    await expect(page.getByTestId("biodiversity-panel")).toBeVisible();
+    await expect(page.getByTestId("biodiversity-predictions-panel")).toBeVisible();
+    await expectErrorMessage(this);
+    await expect(page.getByTestId("predictions-empty-state")).toHaveCount(0);
   },
 );
 
 Then("the search empty state is visible", async function (this: AppWorld) {
-  await expect(getPage(this).getByTestId("search-empty-state")).toBeVisible();
+  const page = getPage(this);
+  await expect(page.getByTestId("search-input")).toBeVisible();
+  await expect(page.getByTestId("search-empty-state")).toBeVisible();
+  await expect(page.getByTestId("search-empty-state")).toContainText(
+    "No projects found",
+  );
+  await expect(
+    page.getByTestId(`project-search-result-${FIXTURE_PROJECT_ID}`),
+  ).toHaveCount(0);
 });

--- a/e2e/step-definitions/error.steps.ts
+++ b/e2e/step-definitions/error.steps.ts
@@ -1,0 +1,111 @@
+import { Given, Then } from "@cucumber/cucumber";
+import { expect } from "@playwright/test";
+import { FIXTURE_PROJECT_ID } from "../fixtures/homepage.js";
+import {
+  installErrorRoute_CommunityMembersFails,
+  installErrorRoute_MeasuredTreesFails,
+  installErrorRoute_PredictionsFails,
+  installErrorRoute_ProjectInfoFails,
+} from "../support/error-routes.js";
+import { getPage } from "../support/utils.js";
+import type { AppWorld } from "../support/world.js";
+
+const ERROR_UI_TIMEOUT = 15_000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Navigates to the fixture project without asserting a successful load state.
+ * Used by error scenarios where the overlay will render an error instead of
+ * the normal project title / panel content.
+ */
+const navigateToFixtureProject = async (
+  world: AppWorld,
+  options: {
+    overlayTab?: "project" | "layers";
+    projectViews?: string;
+  } = {},
+) => {
+  const page = getPage(world);
+  const url = new URL(`/${FIXTURE_PROJECT_ID}`, world.env.appUrl);
+  url.searchParams.set("overlay-active-tab", options.overlayTab ?? "project");
+  if (options.projectViews) {
+    url.searchParams.set("project-views", options.projectViews);
+  }
+  await page.goto(url.toString());
+  // Wait for the overlay container to mount before asserting error state.
+  await expect(page.getByTestId("project-overlay")).toBeVisible();
+};
+
+// ---------------------------------------------------------------------------
+// Given steps — error-injected navigation
+// ---------------------------------------------------------------------------
+
+Given(
+  "the fixture project page is open with a failing project info endpoint",
+  async function (this: AppWorld) {
+    await installErrorRoute_ProjectInfoFails(getPage(this));
+    await navigateToFixtureProject(this);
+  },
+);
+
+Given(
+  "the fixture project page is open on the community view with a failing members endpoint",
+  async function (this: AppWorld) {
+    await installErrorRoute_CommunityMembersFails(getPage(this));
+    await navigateToFixtureProject(this, {
+      projectViews: "community",
+    });
+  },
+);
+
+Given(
+  "the fixture project page is open on the biodiversity predictions view with a failing predictions endpoint",
+  async function (this: AppWorld) {
+    await installErrorRoute_PredictionsFails(getPage(this));
+    await navigateToFixtureProject(this, {
+      projectViews: "biodiversity,predictions",
+    });
+  },
+);
+
+Given(
+  "the fixture project page is open on the biodiversity observations view with a failing measured trees endpoint",
+  async function (this: AppWorld) {
+    await installErrorRoute_MeasuredTreesFails(getPage(this));
+    await navigateToFixtureProject(this, {
+      projectViews: "biodiversity,observations",
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Then steps — error state assertions
+// ---------------------------------------------------------------------------
+
+Then("the project error message is visible", async function (this: AppWorld) {
+  await expect(getPage(this).getByTestId("error-message")).toBeVisible({
+    timeout: ERROR_UI_TIMEOUT,
+  });
+});
+
+Then("the community error message is visible", async function (this: AppWorld) {
+  await expect(getPage(this).getByTestId("error-message")).toBeVisible({
+    timeout: ERROR_UI_TIMEOUT,
+  });
+});
+
+Then(
+  "the biodiversity error message is visible",
+  async function (this: AppWorld) {
+    await expect(getPage(this).getByTestId("error-message")).toBeVisible({
+      timeout: ERROR_UI_TIMEOUT,
+    });
+  },
+);
+
+Then("the search empty state is visible", async function (this: AppWorld) {
+  await expect(getPage(this).getByTestId("search-empty-state")).toBeVisible();
+});

--- a/e2e/support/error-routes.ts
+++ b/e2e/support/error-routes.ts
@@ -1,0 +1,134 @@
+/**
+ * Error route overrides for e2e error-state scenarios.
+ *
+ * Each function registers a Playwright route override on top of the happy-path
+ * mocks already installed by `installMockRoutes`. Playwright resolves routes in
+ * LIFO order, so these overrides win for the duration of the scenario. A fresh
+ * page is created per scenario, so the override naturally disappears during the
+ * `After` hook when the page/context are closed.
+ */
+
+import type { Page, Route } from "@playwright/test";
+
+type GraphQLPayload = {
+  query?: string;
+};
+
+const getGraphQLPayload = (route: Route): GraphQLPayload => {
+  try {
+    return (route.request().postDataJSON() as GraphQLPayload | null) ?? {};
+  } catch {
+    return {};
+  }
+};
+
+const fulfillJsonError = async (route: Route, message: string, status = 500) =>
+  route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify({ error: message, message }),
+  });
+
+/**
+ * Makes `com.atproto.repo.getRecord` return a 500 error so that
+ * `ProjectOverlay` enters the error state and renders `<ErrorMessage>`.
+ *
+ * Scoped to the current scenario's page.
+ */
+export const installErrorRoute_ProjectInfoFails = async (
+  page: Page,
+): Promise<void> => {
+  await page.route(
+    "**/xrpc/com.atproto.repo.getRecord**",
+    async (route) => {
+      await fulfillJsonError(
+        route,
+        "InternalServerError",
+        500,
+      );
+    },
+  );
+};
+
+/**
+ * Makes the `OrganizationMemberRecords` GraphQL query return a 500 error so
+ * that `Community/Members` enters the error state and renders `<ErrorMessage>`.
+ *
+ * Other GraphQL operations in the same scenario fall through to the happy-path
+ * `handleGraphql` handler in `network.ts`.
+ */
+export const installErrorRoute_CommunityMembersFails = async (
+  page: Page,
+): Promise<void> => {
+  await page.route(
+    "**/graphql",
+    async (route) => {
+      const { query = "" } = getGraphQLPayload(route);
+      if (query.includes("OrganizationMemberRecords")) {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({
+            errors: [{ message: "Internal server error" }],
+            data: null,
+          }),
+        });
+        return;
+      }
+      // Not the query we want to intercept — fall through to the next handler.
+      await route.fallback();
+    },
+  );
+};
+
+/**
+ * Makes the `OccurrencesByDidAndKingdom` GraphQL query return a 500 error so
+ * that `Biodiversity/Predictions` enters the error state and renders
+ * `<ErrorMessage>`.
+ *
+ * The predictions panel fires two separate queries (Plantae + Animalia), so
+ * this handler stays active for the whole scenario and intercepts either/both.
+ */
+export const installErrorRoute_PredictionsFails = async (
+  page: Page,
+): Promise<void> => {
+  await page.route("**/graphql", async (route) => {
+    const { query = "" } = getGraphQLPayload(route);
+    if (query.includes("OccurrencesByDidAndKingdom")) {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({
+          errors: [{ message: "Internal server error" }],
+          data: null,
+        }),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+};
+
+/**
+ * Makes the measured-tree observations query fail so the observations panel
+ * enters its explicit error state and renders `<ErrorMessage>`.
+ */
+export const installErrorRoute_MeasuredTreesFails = async (
+  page: Page,
+): Promise<void> => {
+  await page.route("**/graphql", async (route) => {
+    const { query = "" } = getGraphQLPayload(route);
+    if (query.includes("OccurrencesByDidWithDynamic")) {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({
+          errors: [{ message: "Internal server error" }],
+          data: null,
+        }),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+};

--- a/e2e/support/error-routes.ts
+++ b/e2e/support/error-routes.ts
@@ -84,7 +84,8 @@ export const installErrorRoute_CommunityMembersFails = async (
 /**
  * Makes the `OccurrencesByDidAndKingdom` GraphQL query return a 500 error so
  * that `Biodiversity/Predictions` enters the error state and renders
- * `<ErrorMessage>`.
+ * `<ErrorMessage>`. We also fail the legacy S3 fallbacks so the panel cannot
+ * silently degrade into the generic no-data state.
  *
  * The predictions panel fires two separate queries (Plantae + Animalia), so
  * this handler stays active for the whole scenario and intercepts either/both.
@@ -103,6 +104,18 @@ export const installErrorRoute_PredictionsFails = async (
           data: null,
         }),
       });
+      return;
+    }
+    await route.fallback();
+  });
+
+  await page.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    if (
+      url.pathname.includes("/restor/") ||
+      url.pathname.includes("/predictions/")
+    ) {
+      await route.abort("failed");
       return;
     }
     await route.fallback();

--- a/src/app/(map-routes)/(main)/_components/ProjectOverlay/Biodiversity/Predictions/index.tsx
+++ b/src/app/(map-routes)/(main)/_components/ProjectOverlay/Biodiversity/Predictions/index.tsx
@@ -48,100 +48,106 @@ const Predictions = () => {
     );
   }, [data]);
 
+  let content: React.ReactNode;
+
   if (dataStatus === "loading") {
-    return (
+    content = (
       <div className="flex flex-col gap-2">
         <div className="w-full h-32 rounded-xl bg-foreground/10 animate-pulse"></div>
         <div className="w-full h-32 rounded-xl bg-foreground/10 animate-pulse delay-500"></div>
       </div>
     );
-  }
-  if (dataStatus === "error" || !data) {
-    return <ErrorMessage />;
-  }
-
-  return (
-    <article className="flex flex-col gap-2" data-testid="biodiversity-predictions">
-      <AnimatePresence mode="popLayout">
-        {page === null ? (
-          <motion.div
-            className="flex flex-col gap-2"
-            initial={{ opacity: 0, x: -20, filter: "blur(10px)" }}
-            animate={{ opacity: 1, x: 0, filter: "blur(0px)" }}
-            exit={{ opacity: 0, x: -20, filter: "blur(10px)" }}
-            transition={{ duration: 0.3 }}
-            key={"predictions-null"}
-          >
-            <div className="text-muted-foreground text-sm flex items-center gap-2">
-              <Info className="shrink-0" size={16} />
-              <span>
-                Species that have been predicted for this site using species
-                distribution models.
-              </span>
-            </div>
-            {hasNoDataInAnyCategory ? (
-              <div className="flex flex-col items-center justify-center w-full p-4 gap-2 bg-muted rounded-xl">
-                <CircleAlert size={36} className="text-muted-foreground/50" />
-                <span className="text-muted-foreground text-sm">
-                  No biodiversity data found for this site.
+  } else if (dataStatus === "error" || !data) {
+    content = <ErrorMessage />;
+  } else {
+    content = (
+      <article className="flex flex-col gap-2" data-testid="biodiversity-predictions">
+        <AnimatePresence mode="popLayout">
+          {page === null ? (
+            <motion.div
+              className="flex flex-col gap-2"
+              initial={{ opacity: 0, x: -20, filter: "blur(10px)" }}
+              animate={{ opacity: 1, x: 0, filter: "blur(0px)" }}
+              exit={{ opacity: 0, x: -20, filter: "blur(10px)" }}
+              transition={{ duration: 0.3 }}
+              key={"predictions-null"}
+            >
+              <div className="text-muted-foreground text-sm flex items-center gap-2">
+                <Info className="shrink-0" size={16} />
+                <span>
+                  Species that have been predicted for this site using species
+                  distribution models.
                 </span>
               </div>
-            ) : (
-              <ul className="flex flex-col gap-2">
-                {data.treesData.length + data.herbsData.length > 0 && (
-                  <BioGalleryTrigger
-                    title={"Plants"}
-                    description="View all plant predictions"
-                    imageSrc={"/assets/plants.jpg"}
-                    testId="predictions-plants-trigger"
-                    onClick={() => {
-                      setPage("plants");
-                    }}
-                    count={data.treesData.length + data.herbsData.length}
-                  />
-                )}
-                {data.animalsData.length > 0 && (
-                  <BioGalleryTrigger
-                    title={"Animals"}
-                    description="View all animal predictions"
-                    imageSrc={"/assets/animals.jpg"}
-                    testId="predictions-animals-trigger"
-                    onClick={() => {
-                      setPage("animals");
-                    }}
-                    count={data.animalsData.length}
-                  />
-                )}
-              </ul>
-            )}
-          </motion.div>
-        ) : page === "plants" ? (
-          <BioGalleries
-            title={"Plants"}
-            Icon={TreesIcon}
-            key={"predictions-plants"}
-          >
-            <TreesAndHerbs data={data.treesData} type="Trees" />
-            <TreesAndHerbs data={data.herbsData} type="Herbs" />
-          </BioGalleries>
-        ) : (
-          <BioGalleries
-            title={"Animals"}
-            Icon={PawPrint}
-            key={"predictions-animals"}
-          >
-            <Animals data={data.animalsData} />
-          </BioGalleries>
+              {hasNoDataInAnyCategory ? (
+                <div
+                  className="flex flex-col items-center justify-center w-full p-4 gap-2 bg-muted rounded-xl"
+                  data-testid="predictions-empty-state"
+                >
+                  <CircleAlert size={36} className="text-muted-foreground/50" />
+                  <span className="text-muted-foreground text-sm">
+                    No biodiversity data found for this site.
+                  </span>
+                </div>
+              ) : (
+                <ul className="flex flex-col gap-2">
+                  {data.treesData.length + data.herbsData.length > 0 && (
+                    <BioGalleryTrigger
+                      title={"Plants"}
+                      description="View all plant predictions"
+                      imageSrc={"/assets/plants.jpg"}
+                      testId="predictions-plants-trigger"
+                      onClick={() => {
+                        setPage("plants");
+                      }}
+                      count={data.treesData.length + data.herbsData.length}
+                    />
+                  )}
+                  {data.animalsData.length > 0 && (
+                    <BioGalleryTrigger
+                      title={"Animals"}
+                      description="View all animal predictions"
+                      imageSrc={"/assets/animals.jpg"}
+                      testId="predictions-animals-trigger"
+                      onClick={() => {
+                        setPage("animals");
+                      }}
+                      count={data.animalsData.length}
+                    />
+                  )}
+                </ul>
+              )}
+            </motion.div>
+          ) : page === "plants" ? (
+            <BioGalleries
+              title={"Plants"}
+              Icon={TreesIcon}
+              key={"predictions-plants"}
+            >
+              <TreesAndHerbs data={data.treesData} type="Trees" />
+              <TreesAndHerbs data={data.herbsData} type="Herbs" />
+            </BioGalleries>
+          ) : (
+            <BioGalleries
+              title={"Animals"}
+              Icon={PawPrint}
+              key={"predictions-animals"}
+            >
+              <Animals data={data.animalsData} />
+            </BioGalleries>
+          )}
+        </AnimatePresence>
+        {page !== null && (
+          <div className="text-muted-foreground text-sm flex items-center justify-center text-center gap-2">
+            <Info className="shrink-0" size={16} />
+            <span>API provided by Restor</span>
+          </div>
         )}
-      </AnimatePresence>
-      {page !== null && (
-        <div className="text-muted-foreground text-sm flex items-center justify-center text-center gap-2">
-          <Info className="shrink-0" size={16} />
-          <span>API provided by Restor</span>
-        </div>
-      )}
-    </article>
-  );
+      </article>
+    );
+  }
+
+  return <div data-testid="biodiversity-predictions-panel">{content}</div>;
 };
 
 export default Predictions;

--- a/src/app/(map-routes)/(main)/_components/ProjectOverlay/Biodiversity/Predictions/store/index.ts
+++ b/src/app/(map-routes)/(main)/_components/ProjectOverlay/Biodiversity/Predictions/store/index.ts
@@ -82,6 +82,7 @@ const useBiodiversityPredictionsStore = create<
         // Plants: use ATProto if it returned any records, otherwise fall back to S3
         let treesData: BiodiversityPlant[];
         let herbsData: BiodiversityPlant[];
+        let plantsFetchFailed = false;
 
         const atprotoHasPlants =
           atprotoPlants !== null &&
@@ -101,10 +102,13 @@ const useBiodiversityPredictionsStore = create<
           }
           treesData = s3Trees?.items ?? [];
           herbsData = s3Herbs?.items ?? [];
+          plantsFetchFailed =
+            atprotoPlants === null && s3Trees === null && s3Herbs === null;
         }
 
         // Animals: use ATProto if it returned any records, otherwise fall back to S3
         let animalsData: BiodiversityAnimal[];
+        let animalsFetchFailed = false;
 
         const atprotoHasAnimals =
           atprotoAnimals !== null && atprotoAnimals.length > 0;
@@ -118,6 +122,15 @@ const useBiodiversityPredictionsStore = create<
             return;
           }
           animalsData = s3Animals ?? [];
+          animalsFetchFailed = atprotoAnimals === null && s3Animals === null;
+        }
+
+        const hasAnyPredictionData =
+          treesData.length > 0 || herbsData.length > 0 || animalsData.length > 0;
+
+        if ((plantsFetchFailed || animalsFetchFailed) && !hasAnyPredictionData) {
+          set({ dataStatus: "error", data: null });
+          return;
         }
 
         set({

--- a/src/app/(map-routes)/(main)/_components/ProjectOverlay/Biodiversity/index.tsx
+++ b/src/app/(map-routes)/(main)/_components/ProjectOverlay/Biodiversity/index.tsx
@@ -22,7 +22,7 @@ const Biodiversity = () => {
   }, [activeTab]);
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-4" data-testid="biodiversity-panel">
       <SlidingTabs activeKey={activeTab} className="gap-2">
         <Underlay />
         <Tab tabKey="predictions" asChild>

--- a/src/app/(map-routes)/(main)/_components/ProjectOverlay/Community/index.tsx
+++ b/src/app/(map-routes)/(main)/_components/ProjectOverlay/Community/index.tsx
@@ -18,7 +18,7 @@ const Community = () => {
   //   }
   // }, [activeTab]);
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-4" data-testid="community-panel">
       {/* <SlidingTabs activeKey={activeTab} className="gap-2">
         <Underlay />
         <Tab tabKey="members" asChild>

--- a/src/app/(map-routes)/(main)/_components/ProjectOverlay/ErrorMessage.tsx
+++ b/src/app/(map-routes)/(main)/_components/ProjectOverlay/ErrorMessage.tsx
@@ -7,7 +7,7 @@ const ErrorMessage = ({
   message?: React.ReactNode;
 }) => {
   return (
-    <div className="flex flex-col items-center justify-center w-full p-4 gap-2 bg-muted rounded-xl">
+    <div data-testid="error-message" className="flex flex-col items-center justify-center w-full p-4 gap-2 bg-muted rounded-xl">
       <CircleAlert size={36} className="text-muted-foreground/50" />
       <span className="text-muted-foreground text-sm">{message}</span>
     </div>

--- a/src/app/(map-routes)/(main)/_components/SearchOverlay/index.tsx
+++ b/src/app/(map-routes)/(main)/_components/SearchOverlay/index.tsx
@@ -183,7 +183,7 @@ const SearchOverlay = () => {
           </motion.div>
         )}
         {filteredOrganizations && filteredOrganizations.length === 0 && (
-          <div className="bg-foreground/[0.025] p-4 rounded-xl mt-4 flex flex-col items-center justify-center gap-4">
+          <div data-testid="search-empty-state" className="bg-foreground/[0.025] p-4 rounded-xl mt-4 flex flex-col items-center justify-center gap-4">
             <CircleAlert
               className="text-muted-foreground opacity-50"
               size={40}


### PR DESCRIPTION
## Summary
- add mocked homepage error-state scenarios for project, community, biodiversity observations, and empty search results
- add stable test selectors for shared error and empty-state UI assertions
- keep the PR scoped to the new error-state coverage only

## Validation
- bun run test:e2e:headless