### PR TITLE
feat(bumicerts): tree preview iframe embed with cross-PDS support

### DIFF
--- a/e2e/support/error-routes.ts
+++ b/e2e/support/error-routes.ts
@@ -125,13 +125,26 @@ export const installErrorRoute_PredictionsFails = async (
 /**
  * Makes the measured-tree observations query fail so the observations panel
  * enters its explicit error state and renders `<ErrorMessage>`.
+ *
+ * We fail two upstream calls:
+ *   1. The hyperindex GraphQL occurrence query (`OccurrencesByDid` /
+ *      `OccurrencesByDidWithDynamic`).
+ *   2. The PDS `listRecords` XRPC for `app.gainforest.dwc.measurement`.
+ *
+ * The app now tolerates hyperindex schema drift by catching the GraphQL
+ * error and falling back to PDS-only data. To still exercise the error UX
+ * end-to-end, we also fail the measurement listRecords call — its rejection
+ * propagates out of `fetchMeasurementIndex` and surfaces the error state.
  */
 export const installErrorRoute_MeasuredTreesFails = async (
   page: Page,
 ): Promise<void> => {
   await page.route("**/graphql", async (route) => {
     const { query = "" } = getGraphQLPayload(route);
-    if (query.includes("OccurrencesByDidWithDynamic")) {
+    if (
+      query.includes("OccurrencesByDidWithDynamic") ||
+      query.includes("OccurrencesByDid(")
+    ) {
       await route.fulfill({
         status: 500,
         contentType: "application/json",
@@ -144,4 +157,16 @@ export const installErrorRoute_MeasuredTreesFails = async (
     }
     await route.fallback();
   });
+
+  await page.route(
+    "**/xrpc/com.atproto.repo.listRecords**",
+    async (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get("collection") === "app.gainforest.dwc.measurement") {
+        await fulfillJsonError(route, "InternalServerError", 500);
+        return;
+      }
+      await route.fallback();
+    },
+  );
 };

--- a/e2e/support/network.ts
+++ b/e2e/support/network.ts
@@ -115,7 +115,10 @@ const handleGraphql = async (route: Route) => {
     }
   }
 
-  if (query.includes("query OccurrencesByDidWithDynamic")) {
+  if (
+    query.includes("query OccurrencesByDidWithDynamic") ||
+    query.includes("query OccurrencesByDid(")
+  ) {
     return fulfillJson(route, OBSERVATION_OCCURRENCES_RESPONSE);
   }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,13 @@ const remotePatterns = [
     hostname: "climateai.org", // ATProto PDS
   },
   {
+    // Allow blobs from any ATProto PDS (e.g. gainforest.id) — scoped to the
+    // canonical XRPC blob path so we don't accidentally proxy arbitrary hosts.
+    protocol: "https" as const,
+    hostname: "**",
+    pathname: "/xrpc/com.atproto.sync.getBlob",
+  },
+  {
     protocol: "https" as const,
     hostname: "kf.kobotoolbox.org", // KoboToolbox (still used as fallback)
   },

--- a/src/app/(map-routes)/(main)/_components/Map/hooks/useBounds.ts
+++ b/src/app/(map-routes)/(main)/_components/Map/hooks/useBounds.ts
@@ -9,6 +9,7 @@ import useOverlayStore from "../../Overlay/store";
 const useBounds = () => {
   const bounds = useMapStore((state) => state.mapBounds);
   const mapRef = useMapStore((state) => state.mapRef);
+  const mapLoaded = useMapStore((state) => state.mapLoaded);
 
   const isOverlayOpen = useOverlayStore((state) => state.isOpen);
   const size = useOverlayStore((state) => state.size);
@@ -17,7 +18,7 @@ const useBounds = () => {
 
   useEffect(() => {
     const map = mapRef?.current;
-    if (!map || !bounds) return;
+    if (!mapLoaded || !map || !bounds) return;
 
     map.fitBounds(bounds, {
       padding: {
@@ -27,7 +28,7 @@ const useBounds = () => {
         right: 40,
       },
     });
-  }, [mapRef, bounds, shouldAddExtraLeftPadding]);
+  }, [mapLoaded, mapRef, bounds, shouldAddExtraLeftPadding]);
 };
 
 export default useBounds;

--- a/src/app/(map-routes)/(main)/_components/Map/hooks/useHoveredTreeInfo.ts
+++ b/src/app/(map-routes)/(main)/_components/Map/hooks/useHoveredTreeInfo.ts
@@ -24,7 +24,7 @@ export function useHoveredTreeInfo() {
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // Create a ref to track the currently hovered tree ID
-  const hoveredTreeIdRef = useRef<number | null>(null);
+  const hoveredTreeIdRef = useRef<string | number | null>(null);
 
   // Debounced version of setTreeInformation
   const debouncedSetTreesInformation = useCallback(
@@ -48,11 +48,12 @@ export function useHoveredTreeInfo() {
       const treeInformation = getTreeInformation(e, activeProjectId);
       debouncedSetTreesInformation(treeInformation);
 
-      if (hoveredTreeIdRef.current !== null) {
+      if (hoveredTreeIdRef.current != null) {
         map.setFeatureState(
           { source: "trees", id: hoveredTreeIdRef.current },
           { hover: false }
         );
+        hoveredTreeIdRef.current = null;
       }
 
       const hoveredTreeFeature = e.features.find((feature) => {
@@ -64,6 +65,10 @@ export function useHoveredTreeInfo() {
       }) as NormalizedTreeFeature | undefined;
 
       if (!hoveredTreeFeature) return;
+      // Mapbox's Supercluster pipeline can drop string feature ids, leaving
+      // `id` undefined on the rendered feature. setFeatureState throws on
+      // null/undefined ids, so skip the hover-state write when that happens.
+      if (hoveredTreeFeature.id == null) return;
       hoveredTreeIdRef.current = hoveredTreeFeature.id;
       map.setFeatureState(
         { source: "trees", id: hoveredTreeFeature.id },

--- a/src/app/(map-routes)/(main)/_components/Map/hooks/useProjectTrees.ts
+++ b/src/app/(map-routes)/(main)/_components/Map/hooks/useProjectTrees.ts
@@ -2,9 +2,16 @@ import { useEffect } from "react";
 import useMapStore from "../store";
 import { GeoJSONSource } from "mapbox-gl";
 import useProjectOverlayStore from "../../ProjectOverlay/store";
+import type { MeasuredTreesGeoJSON } from "../../ProjectOverlay/store/types";
+
+const EMPTY_TREES_GEOJSON: MeasuredTreesGeoJSON = {
+  type: "FeatureCollection",
+  features: [],
+};
 
 const useProjectTrees = () => {
   const mapRef = useMapStore((state) => state.mapRef);
+  const mapLoaded = useMapStore((state) => state.mapLoaded);
   const currentView = useMapStore((state) => state.currentView);
   const projectTreesAsync = useProjectOverlayStore((state) => state.treesAsync);
 
@@ -13,12 +20,12 @@ const useProjectTrees = () => {
   useEffect(() => {
     if (currentView !== "project") return;
     const map = mapRef?.current;
-    if (!map || !projectTrees) return;
+    if (!mapLoaded || !map) return;
 
     (map.getSource("trees") as GeoJSONSource | undefined)?.setData(
-      projectTrees
+      projectTrees ?? EMPTY_TREES_GEOJSON,
     );
-  }, [mapRef, currentView, projectTrees]);
+  }, [mapLoaded, mapRef, currentView, projectTrees]);
 };
 
 export default useProjectTrees;

--- a/src/app/(map-routes)/(main)/_components/Map/hooks/useSelectedTreeHighlight.ts
+++ b/src/app/(map-routes)/(main)/_components/Map/hooks/useSelectedTreeHighlight.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from "react";
+import useMapStore from "../store";
+import useProjectOverlayStore from "../../ProjectOverlay/store";
+import usePreviewStore from "../../../_features/preview/store";
+
+type FeatureIdentifier = string | number;
+
+const useSelectedTreeHighlight = () => {
+  const currentView = useMapStore((state) => state.currentView);
+  const mapRef = useMapStore((state) => state.mapRef);
+  const mapLoaded = useMapStore((state) => state.mapLoaded);
+  const activeProjectId = useProjectOverlayStore((state) => state.projectId);
+  const treesAsync = useProjectOverlayStore((state) => state.treesAsync);
+  const selectedTreeUri = usePreviewStore((state) => state.treeUri);
+
+  const selectedFeatureIdRef = useRef<FeatureIdentifier | null>(null);
+
+  useEffect(() => {
+    if (currentView !== "project" || !activeProjectId) {
+      return;
+    }
+
+    const map = mapRef?.current;
+    if (!mapLoaded || !map || !map.getSource("trees")) {
+      return;
+    }
+
+    const previousFeatureId = selectedFeatureIdRef.current;
+    if (previousFeatureId !== null) {
+      map.setFeatureState(
+        { source: "trees", id: previousFeatureId },
+        { selected: false },
+      );
+      selectedFeatureIdRef.current = null;
+    }
+
+    if (treesAsync?._status !== "success" || !selectedTreeUri) {
+      return;
+    }
+
+    const matchingFeature = treesAsync.data?.features.find(
+      (feature) => feature.properties.occurrenceUri === selectedTreeUri,
+    );
+
+    if (!matchingFeature) {
+      return;
+    }
+
+    map.setFeatureState(
+      { source: "trees", id: matchingFeature.id },
+      { selected: true },
+    );
+    selectedFeatureIdRef.current = matchingFeature.id;
+
+    return () => {
+      const featureId = selectedFeatureIdRef.current;
+      if (featureId !== null && map.getSource("trees")) {
+        map.setFeatureState({ source: "trees", id: featureId }, { selected: false });
+      }
+      selectedFeatureIdRef.current = null;
+    };
+  }, [activeProjectId, currentView, mapLoaded, mapRef, selectedTreeUri, treesAsync]);
+};
+
+export default useSelectedTreeHighlight;

--- a/src/app/(map-routes)/(main)/_components/Map/index.tsx
+++ b/src/app/(map-routes)/(main)/_components/Map/index.tsx
@@ -10,6 +10,7 @@ import useDynamicLayers from "./hooks/useDynamicLayers";
 import useBounds from "./hooks/useBounds";
 import useHighlightedPolygon from "./hooks/useHighlightedPolygon";
 import useLandcoverLayer from "./hooks/useLandcoverLayer";
+import useSelectedTreeHighlight from "./hooks/useSelectedTreeHighlight";
 
 const Map = () => {
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
@@ -19,6 +20,7 @@ const Map = () => {
   useHighlightedPolygon();
   useProjectTrees();
   useHoveredTreeInfo();
+  useSelectedTreeHighlight();
   useLandcoverLayer();
   useDynamicLayers();
 

--- a/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/measured-trees.ts
+++ b/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/measured-trees.ts
@@ -62,18 +62,32 @@ export const unclusteredTreesLayer: CircleLayerSpecification = {
   paint: {
     "circle-color": [
       "case",
+      ["boolean", ["feature-state", "selected"], false],
+      "#ec4899",
       ["boolean", ["feature-state", "hover"], false],
       "#0883fe",
       "#ff77c1",
     ],
     "circle-radius": [
       "case",
+      ["boolean", ["feature-state", "selected"], false],
+      10,
       ["boolean", ["feature-state", "hover"], false],
       8,
       4,
     ],
-    "circle-stroke-width": 1,
-    "circle-stroke-color": "#000000",
+    "circle-stroke-width": [
+      "case",
+      ["boolean", ["feature-state", "selected"], false],
+      3,
+      1,
+    ],
+    "circle-stroke-color": [
+      "case",
+      ["boolean", ["feature-state", "selected"], false],
+      "#ffffff",
+      "#000000",
+    ],
   },
 };
 

--- a/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/index.ts
+++ b/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/index.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { AtprotoSite, Project } from "./types";
+import { AtprotoSite, Project, ProjectPolygonAPIResponse } from "./types";
 import {
   fetchMeasuredTreesShapefile,
   fetchSiteShapefile,
@@ -13,7 +13,8 @@ import {
   convertFromGFTreeFeatureToNormalizedTreeFeature,
 } from "./ayyoweca-uganda";
 import useNavigation from "@/app/(map-routes)/(main)/_features/navigation/use-navigation";
-import ClimateAIAgent from "@/lib/atproto/agent";
+import { Agent } from "@atproto/api";
+import { resolvePdsEndpoint } from "@/lib/atproto/resolve-pds";
 import { fetchMeasuredTreeOccurrences } from "../../../_hooks/use-organization-measured-trees";
 import { hyperindexClient } from "@/lib/hyperindex/client";
 import {
@@ -25,6 +26,7 @@ import type {
   HiCertifiedLocation,
   HiOrganizationDefaultSite,
 } from "@/lib/hyperindex/types";
+import usePreviewStore from "../../../_features/preview/store";
 
 // ---------------------------------------------------------------------------
 // ATProto collections
@@ -104,7 +106,9 @@ const SLUG_OVERRIDES: Record<string, string> = {
 
 const fetchOrganizationSlug = async (did: string): Promise<string | null> => {
   try {
-    const response = await ClimateAIAgent.com.atproto.repo.describeRepo({
+    const pdsEndpoint = await resolvePdsEndpoint(did);
+    const agent = new Agent(pdsEndpoint);
+    const response = await agent.com.atproto.repo.describeRepo({
       repo: did,
     });
     const handle = response.data.handle ?? null;
@@ -112,7 +116,10 @@ const fetchOrganizationSlug = async (did: string): Promise<string | null> => {
     const rawSlug = handle.split('.')[0] ?? null;
     if (!rawSlug) return null;
     return SLUG_OVERRIDES[rawSlug] ?? rawSlug;
-  } catch {
+  } catch (err) {
+    if (process.env.NODE_ENV === "development") {
+      console.warn("[GG] fetchOrganizationSlug failed:", did, err);
+    }
     return null;
   }
 };
@@ -142,6 +149,88 @@ const buildCompatProject = (did: string, slug: string): Project => ({
   communityMembers: [],
   Wallet: null,
 });
+
+const applyPreviewFilters = (
+  data: MeasuredTreesGeoJSON | null,
+): MeasuredTreesGeoJSON | null => {
+  if (!data) {
+    return null;
+  }
+
+  const { datasetRef, treeUri } = usePreviewStore.getState();
+
+  if (!datasetRef && !treeUri) {
+    return data;
+  }
+
+  const datasetFiltered = datasetRef
+    ? data.features.filter((feature) => feature.properties.datasetRef === datasetRef)
+    : data.features;
+
+  const treeFiltered = treeUri
+    ? data.features.filter((feature) => feature.properties.occurrenceUri === treeUri)
+    : [];
+
+  const featureMap = new Map<string | number, (typeof data.features)[number]>();
+  for (const feature of datasetFiltered) {
+    featureMap.set(feature.id, feature);
+  }
+  for (const feature of treeFiltered) {
+    featureMap.set(feature.id, feature);
+  }
+
+  const features = [...featureMap.values()];
+
+  if (datasetRef && features.length === 0) {
+    return {
+      ...data,
+      features: treeFiltered,
+    };
+  }
+
+  return {
+    ...data,
+    features,
+  };
+};
+
+const setMapBoundsFromTrees = (data: MeasuredTreesGeoJSON | null) => {
+  if (!data || data.features.length === 0) {
+    return;
+  }
+
+  const { treeUri } = usePreviewStore.getState();
+  if (treeUri) {
+    const selectedFeature = data.features.find(
+      (feature) => feature.properties.occurrenceUri === treeUri,
+    );
+
+    if (selectedFeature) {
+      const [lon, lat] = selectedFeature.geometry.coordinates;
+      const offset = 0.0025;
+      useMapStore.getState().setMapBounds([
+        lon - offset,
+        lat - offset,
+        lon + offset,
+        lat + offset,
+      ]);
+      return;
+    }
+  }
+
+  const boundingBox = bbox(data).slice(0, 4) as [
+    number,
+    number,
+    number,
+    number,
+  ];
+  useMapStore.getState().setMapBounds(boundingBox);
+};
+
+const shouldUsePreviewBounds = (): boolean => {
+  const { embedMode, datasetRef, treeUri } = usePreviewStore.getState();
+  return embedMode || datasetRef !== null || treeUri !== null;
+};
 
 // ---------------------------------------------------------------------------
 // Store types
@@ -221,6 +310,7 @@ export type ProjectOverlayActions = {
     tab: ProjectOverlayState["activeTab"],
     navigate?: ReturnType<typeof useNavigation>
   ) => void;
+  refreshTrees: () => void;
   resetState: () => void;
   setIsMaximized: (isMaximized: ProjectOverlayState["isMaximized"]) => void;
 };
@@ -247,6 +337,74 @@ const useProjectOverlayStore = create<
   ProjectOverlayState & ProjectOverlayActions
 >((set, get) => {
   const isProjectStillActive = (id: string) => get().projectId === id;
+
+  const loadProjectTrees = async (
+    projectId: string,
+    projectSlug: string | null,
+    treesRef: unknown,
+    shouldFitToSite?: boolean,
+  ) => {
+    const slug = projectSlug ?? "";
+    const isAyyowecaUganda =
+      projectId ===
+      "49bbaba0d8980989ce9b3988a45c375a42206239d6bc930c2357035e670838e0";
+
+    try {
+      const occurrenceData = await fetchMeasuredTreeOccurrences(projectId);
+      if (!isProjectStillActive(projectId)) {
+        return;
+      }
+
+      if (occurrenceData !== null) {
+        const filteredOccurrenceData = applyPreviewFilters(occurrenceData);
+        set({ treesAsync: { _status: "success", data: filteredOccurrenceData } });
+
+        if (
+          filteredOccurrenceData &&
+          (shouldUsePreviewBounds() || !shouldFitToSite)
+        ) {
+          setMapBoundsFromTrees(filteredOccurrenceData);
+        }
+        return;
+      }
+
+      const rawData = await fetchMeasuredTreesShapefile(slug, treesRef, projectId);
+      if (!isProjectStillActive(projectId)) {
+        return;
+      }
+
+      let data: MeasuredTreesGeoJSON | null = rawData;
+
+      if (isAyyowecaUganda && rawData !== null) {
+        const gfTreeFeatures = rawData as unknown as {
+          type: "FeatureCollection";
+          features: GFTreeFeature[];
+        };
+        data = {
+          type: "FeatureCollection",
+          features: gfTreeFeatures.features.map(
+            convertFromGFTreeFeatureToNormalizedTreeFeature,
+          ),
+        };
+      }
+
+      const filteredData = applyPreviewFilters(data);
+      set({ treesAsync: { _status: "success", data: filteredData } });
+
+      if (
+        filteredData &&
+        (shouldUsePreviewBounds() || !shouldFitToSite)
+      ) {
+        setMapBoundsFromTrees(filteredData);
+      }
+    } catch (error) {
+      console.error("Error fetching measured trees", error);
+      if (!isProjectStillActive(projectId)) {
+        return;
+      }
+      set({ treesAsync: { _status: "error", data: null } });
+    }
+  };
 
   return {
     ...initialState,
@@ -366,94 +524,45 @@ const useProjectOverlayStore = create<
       if (!atprotoSites || !projectId) return;
 
       const selectedSite = atprotoSites.find((site) => site.uri === siteId);
-      if (!selectedSite) return;
 
       useMapStore.getState().setCurrentView("project");
 
-      fetchSiteShapefile(projectId, selectedSite.shapefile).then((data) => {
-        if (data === null) return;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const boundingBox = bbox(data as any).slice(0, 4) as [
-          number,
-          number,
-          number,
-          number
-        ];
-        if (zoomToSite) {
-          useMapStore.getState().setMapBounds(boundingBox);
-        }
-        navigate?.((draft) => {
-          if (draft.map.bounds !== null) {
-            draft.map.bounds = null;
-          }
-        });
-        // Cast to ProjectPolygonAPIResponse for Map store compatibility
-        // (both are GeoJSON FeatureCollections at runtime)
-        useMapStore
-          .getState()
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .setHighlightedPolygon(data as any);
-      });
-
       set({
-        activeSite: selectedSite,
+        activeSite: selectedSite ?? null,
         treesAsync: { _status: "loading", data: null },
       });
 
-      // Fetch measured trees for this site.
-      // Priority:
-      //   1. dwc.occurrence records (migrated orgs) — via fetchMeasuredTreeOccurrences
-      //   2. ATProto blob / S3 fallback (non-migrated orgs) — via fetchMeasuredTreesShapefile
-      const slug = projectSlug ?? "";
-      const treesRef = selectedSite.trees;
-
-      const isAyyowecaUganda =
-        projectId ===
-        "49bbaba0d8980989ce9b3988a45c375a42206239d6bc930c2357035e670838e0";
-
-      (async () => {
-        try {
-          // Path 1: Try dwc.occurrence records first (migrated orgs)
-          const occurrenceData = await fetchMeasuredTreeOccurrences(projectId);
-          if (!isProjectStillActive(projectId)) return;
-
-          if (occurrenceData !== null) {
-            // Org has been migrated — use occurrence data directly
-            set({ treesAsync: { _status: "success", data: occurrenceData } });
-            return;
+      if (selectedSite) {
+        fetchSiteShapefile(projectId, selectedSite.shapefile).then((data) => {
+          if (data === null) return;
+          const boundingBox = bbox(data as unknown as GeoJSON.FeatureCollection).slice(0, 4) as [
+            number,
+            number,
+            number,
+            number,
+          ];
+          if (zoomToSite && !shouldUsePreviewBounds()) {
+            useMapStore.getState().setMapBounds(boundingBox);
           }
-
-          // Path 2: Fall back to legacy GeoJSON blob / S3 path (non-migrated orgs)
-          const rawData = await fetchMeasuredTreesShapefile(
-            slug,
-            treesRef,
-            projectId
+          navigate?.((draft) => {
+            if (draft.map.bounds !== null && !shouldUsePreviewBounds()) {
+              draft.map.bounds = null;
+            }
+          });
+          useMapStore.getState().setHighlightedPolygon(
+            data as unknown as ProjectPolygonAPIResponse,
           );
-          if (!isProjectStillActive(projectId)) return;
+        });
+      } else {
+        useMapStore.getState().setHighlightedPolygon(null);
+      }
 
-          let data: MeasuredTreesGeoJSON | null = rawData;
-
-          if (isAyyowecaUganda && rawData !== null) {
-            // The Ayyoweca Uganda project uses a different GeoJSON schema
-            const gfTreeFeatures = rawData as unknown as {
-              type: "FeatureCollection";
-              features: GFTreeFeature[];
-            };
-            data = {
-              type: "FeatureCollection",
-              features: gfTreeFeatures.features.map(
-                convertFromGFTreeFeatureToNormalizedTreeFeature
-              ),
-            };
-          }
-
-          set({ treesAsync: { _status: "success", data } });
-        } catch (error) {
-          console.error("Error fetching measured trees", error);
-          if (!isProjectStillActive(projectId)) return;
-          set({ treesAsync: { _status: "error", data: null } });
-        }
-      })();
+      void loadProjectTrees(
+        projectId,
+        projectSlug,
+        selectedSite?.trees,
+        Boolean(selectedSite),
+      );
     },
     setActiveTab: (tab, navigate) => {
       set({ activeTab: tab });
@@ -462,6 +571,20 @@ const useProjectOverlayStore = create<
         if (!project) return;
         project.views = [tab];
       });
+    },
+    refreshTrees: () => {
+      const { projectId, projectSlug, activeSite, projectDataStatus } = get();
+      if (!projectId || projectDataStatus !== "success") {
+        return;
+      }
+
+      set({ treesAsync: { _status: "loading", data: null } });
+      void loadProjectTrees(
+        projectId,
+        projectSlug,
+        activeSite?.trees,
+        Boolean(activeSite),
+      );
     },
     setIsMaximized: (isMaximized) => {
       set({ isMaximized });

--- a/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/types.ts
+++ b/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/types.ts
@@ -106,6 +106,10 @@ export type ProjectPolygonAPIResponse = {
 export type TreeFeatureProperties = {
   lat: number;
   lon: number;
+  occurrenceUri?: string;
+  datasetRef?: string;
+  siteRef?: string;
+  treeSource?: string;
   Height?: string;
   height?: string;
   diameter?: string;
@@ -142,7 +146,7 @@ export type TreeFeature = {
 };
 
 export type NormalizedTreeFeature = TreeFeature & {
-  id: number;
+  id: string | number;
   properties: TreeFeatureProperties & {
     type: "measured-tree";
   };
@@ -156,4 +160,3 @@ export type MeasuredTreesGeoJSON<
   type: "FeatureCollection";
   features: T[];
 };
-

--- a/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/utils.ts
+++ b/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/utils.ts
@@ -5,8 +5,8 @@ import {
   TreeFeature,
 } from "./types";
 import { getTreeSpeciesName } from "../../Map/sources-and-layers/measured-trees";
-import { PDS_ENDPOINT } from "@/config/atproto";
 import { extractCid } from "@/lib/atproto/extract-cid";
+import { resolvePdsEndpoint } from "@/lib/atproto/resolve-pds";
 
 // ---------------------------------------------------------------------------
 // ATProto blob ref shape (subset of what the PDS returns)
@@ -76,7 +76,8 @@ export const fetchSiteShapefile = async (
       ? extractCid(resolvedShapefile.ref)
       : null;
     if (cid) {
-      const url = `${PDS_ENDPOINT}/xrpc/com.atproto.sync.getBlob?did=${encodeURIComponent(did)}&cid=${encodeURIComponent(cid)}`;
+      const pdsEndpoint = await resolvePdsEndpoint(did);
+      const url = `${pdsEndpoint}/xrpc/com.atproto.sync.getBlob?did=${encodeURIComponent(did)}&cid=${encodeURIComponent(cid)}`;
       const response = await fetch(url);
       if (!response.ok) {
         console.error(
@@ -94,7 +95,8 @@ export const fetchSiteShapefile = async (
       const parsed = parseAtUri(resolvedShapefile);
       if (!parsed) return null;
 
-      const recordUrl = `${PDS_ENDPOINT}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(parsed.repo)}&collection=${encodeURIComponent(parsed.collection)}&rkey=${encodeURIComponent(parsed.rkey)}`;
+      const pdsEndpoint = await resolvePdsEndpoint(parsed.repo);
+      const recordUrl = `${pdsEndpoint}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(parsed.repo)}&collection=${encodeURIComponent(parsed.collection)}&rkey=${encodeURIComponent(parsed.rkey)}`;
       const recordResponse = await fetch(recordUrl);
       if (!recordResponse.ok) return null;
       const record = (await recordResponse.json()) as {
@@ -108,7 +110,7 @@ export const fetchSiteShapefile = async (
         : null;
       if (!resolvedCid) return null;
       const cid = resolvedCid;
-      const blobUrl = `${PDS_ENDPOINT}/xrpc/com.atproto.sync.getBlob?did=${encodeURIComponent(parsed.repo)}&cid=${encodeURIComponent(cid)}`;
+      const blobUrl = `${pdsEndpoint}/xrpc/com.atproto.sync.getBlob?did=${encodeURIComponent(parsed.repo)}&cid=${encodeURIComponent(cid)}`;
       const blobResponse = await fetch(blobUrl);
       if (!blobResponse.ok) {
         console.error(
@@ -193,7 +195,8 @@ export const fetchMeasuredTreesShapefile = async (
   if (treeCid && did) {
     const cid = treeCid;
     try {
-      const url = `${PDS_ENDPOINT}/xrpc/com.atproto.sync.getBlob?did=${encodeURIComponent(did)}&cid=${encodeURIComponent(cid)}`;
+      const pdsEndpoint = await resolvePdsEndpoint(did);
+      const url = `${pdsEndpoint}/xrpc/com.atproto.sync.getBlob?did=${encodeURIComponent(did)}&cid=${encodeURIComponent(cid)}`;
       const response = await fetch(url);
       if (response.ok) {
         const result =

--- a/src/app/(map-routes)/(main)/_features/navigation/use-store-url-sync.ts
+++ b/src/app/(map-routes)/(main)/_features/navigation/use-store-url-sync.ts
@@ -8,22 +8,36 @@ import useLayersOverlayStore from "../../_components/LayersOverlay/store";
 import useSearchOverlayStore from "../../_components/SearchOverlay/store";
 import { updateDedicatedStoresFromViews } from "../../_features/navigation/utils/project";
 import useMapStore from "../../_components/Map/store";
+import usePreviewStore from "../preview/store";
 
 const useStoreUrlSync = (
   queryParams: ReadonlyURLSearchParams,
   params: {
     projectId?: string;
+    embed?: boolean;
   }
 ) => {
-  const { projectId: projectIdParam } = params;
+  const { projectId: projectIdParam, embed = false } = params;
 
   // ⚠️⚠️⚠️ Make sure to update the dependencies, in case of changes to the props.
   useEffect(() => {
+    const nextPreviewState = {
+      embedMode: embed,
+      treeUri: queryParams.get("tree-uri"),
+      datasetRef: queryParams.get("dataset-ref"),
+    };
+    const previousPreviewState = usePreviewStore.getState();
+    const previewChanged =
+      previousPreviewState.embedMode !== nextPreviewState.embedMode ||
+      previousPreviewState.treeUri !== nextPreviewState.treeUri ||
+      previousPreviewState.datasetRef !== nextPreviewState.datasetRef;
+
     const navigationState = generateNavigationStateFromURL(
       projectIdParam ? `/${projectIdParam}` : "",
       queryParams
     );
     useNavigationStore.getState().updateNavigationState(navigationState);
+    usePreviewStore.getState().setPreviewState(nextPreviewState);
 
     // Overlay
     const overlay = useNavigationStore.getState().overlay;
@@ -40,7 +54,7 @@ const useStoreUrlSync = (
     const project = useNavigationStore.getState().project;
     let map = useNavigationStore.getState().map;
     if (project) {
-      const { projectId, setProjectId } = useProjectOverlayStore.getState();
+      const { projectId, setProjectId, refreshTrees } = useProjectOverlayStore.getState();
 
       // Project & Map bounds
       if (project["project-id"] !== projectId) {
@@ -57,6 +71,10 @@ const useStoreUrlSync = (
       }
 
       updateDedicatedStoresFromViews(project["views"]);
+
+      if (previewChanged && project["project-id"] === projectId) {
+        refreshTrees();
+      }
     }
 
     // Layers
@@ -80,7 +98,8 @@ const useStoreUrlSync = (
     if (map["bounds"] !== null && map["bounds"].length === 4) {
       setMapBounds(map["bounds"]);
     }
-  }, [projectIdParam, queryParams]);
+
+  }, [embed, projectIdParam, queryParams]);
 };
 
 export default useStoreUrlSync;

--- a/src/app/(map-routes)/(main)/_features/preview/store.ts
+++ b/src/app/(map-routes)/(main)/_features/preview/store.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+
+export type PreviewState = {
+  embedMode: boolean;
+  treeUri: string | null;
+  datasetRef: string | null;
+};
+
+type PreviewActions = {
+  setPreviewState: (state: PreviewState) => void;
+};
+
+const initialState: PreviewState = {
+  embedMode: false,
+  treeUri: null,
+  datasetRef: null,
+};
+
+const usePreviewStore = create<PreviewState & PreviewActions>((set) => ({
+  ...initialState,
+  setPreviewState: (state) => {
+    set(state);
+  },
+}));
+
+export default usePreviewStore;

--- a/src/app/(map-routes)/(main)/_hooks/use-organization-measured-trees.ts
+++ b/src/app/(map-routes)/(main)/_hooks/use-organization-measured-trees.ts
@@ -1,18 +1,24 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import ClimateAIAgent from "@/lib/atproto/agent";
+import { Agent } from "@atproto/api";
+import { resolvePdsEndpoint } from "@/lib/atproto/resolve-pds";
 import type {
   MeasuredTreesGeoJSON,
   NormalizedTreeFeature,
 } from "../_components/ProjectOverlay/store/types";
 import { getTreeSpeciesName } from "../_components/Map/sources-and-layers/measured-trees";
-import { fetchMultimediaByOccurrence } from "@/lib/atproto/ac-multimedia";
+import {
+  fetchMultimediaByOccurrence,
+  type MultimediaByOccurrence,
+} from "@/lib/atproto/ac-multimedia";
 import { hyperindexClient } from "@/lib/hyperindex/client";
-import { OCCURRENCES_BY_DID_WITH_DYNAMIC } from "@/lib/hyperindex/queries";
+import { OCCURRENCES_BY_DID } from "@/lib/hyperindex/queries";
 import type { Connection, HiDwcOccurrence } from "@/lib/hyperindex/types";
+import usePreviewStore from "../_features/preview/store";
 
 const MEASUREMENT_COLLECTION = "app.gainforest.dwc.measurement";
+const OCCURRENCE_COLLECTION = "app.gainforest.dwc.occurrence";
 
 // ── Constants ──────────────────────────────────────────────────────────────────
 
@@ -22,12 +28,14 @@ type RawOccurrenceValue = {
   basisOfRecord?: unknown;
   scientificName?: unknown;
   vernacularName?: unknown;
+  kingdom?: unknown;
   decimalLatitude?: unknown;
   decimalLongitude?: unknown;
   dynamicProperties?: unknown;
   associatedMedia?: unknown;
   eventDate?: unknown;
   siteRef?: unknown;
+  datasetRef?: unknown;
   [k: string]: unknown;
 };
 
@@ -82,13 +90,14 @@ type MeasurementsByOccurrence = Map<
  * still reflects the old flat schema instead of the bundled `result` format.
  */
 const fetchMeasurementIndex = async (
+  agent: Agent,
   did: string,
 ): Promise<MeasurementsByOccurrence> => {
   const index: MeasurementsByOccurrence = new Map();
   let cursor: string | undefined;
 
   do {
-    const response = await ClimateAIAgent.com.atproto.repo.listRecords({
+    const response = await agent.com.atproto.repo.listRecords({
       repo: did,
       collection: MEASUREMENT_COLLECTION,
       limit: 100,
@@ -156,11 +165,14 @@ const mapOccurrenceNodeToRawRecord = (
     basisOfRecord: node.basisOfRecord,
     scientificName: node.scientificName,
     vernacularName: node.vernacularName,
+    kingdom: node.kingdom,
     decimalLatitude: node.decimalLatitude,
     decimalLongitude: node.decimalLongitude,
     dynamicProperties: node.dynamicProperties,
     associatedMedia: node.associatedMedia,
     eventDate: node.eventDate,
+    siteRef: node.siteRef,
+    datasetRef: node.datasetRef,
   },
 });
 
@@ -170,29 +182,305 @@ const fetchMeasuredTreeOccurrenceRecords = async (
   const records: RawOccurrenceRecord[] = [];
   let cursor: string | null = null;
 
+  try {
+    do {
+      const response: OccurrenceResponse = await hyperindexClient.request(
+        OCCURRENCES_BY_DID,
+        {
+          did,
+          first: 100,
+          after: cursor,
+          basisOfRecord: "HumanObservation",
+        }
+      );
+
+      const connection = response.appGainforestDwcOccurrence;
+      records.push(
+        ...connection.edges.map((edge) =>
+          mapOccurrenceNodeToRawRecord(edge.node),
+        ),
+      );
+
+      cursor = connection.pageInfo.hasNextPage
+        ? connection.pageInfo.endCursor
+        : null;
+    } while (cursor);
+  } catch (err) {
+    // Hyperindex schema may lag the PDS (e.g. new fields not yet indexed).
+    // Degrade gracefully — the PDS listRecords fetch below still surfaces
+    // the data needed to render the tree.
+    if (process.env.NODE_ENV === "development") {
+      console.warn(
+        "[GG] hyperindex occurrences fetch failed, falling back to PDS:",
+        err,
+      );
+    }
+    return [];
+  }
+
+  return records;
+};
+
+const fetchPdsOccurrenceRecords = async (
+  agent: Agent,
+  did: string,
+): Promise<RawOccurrenceRecord[]> => {
+  const records: RawOccurrenceRecord[] = [];
+  let cursor: string | undefined;
+
   do {
-    const response: OccurrenceResponse = await hyperindexClient.request(
-      OCCURRENCES_BY_DID_WITH_DYNAMIC,
-      {
-        did,
-        first: 100,
-        after: cursor,
-        basisOfRecord: "HumanObservation",
-        dynamicContains: "measuredTree",
+    const response = await agent.com.atproto.repo.listRecords({
+      repo: did,
+      collection: OCCURRENCE_COLLECTION,
+      limit: 100,
+      cursor,
+    });
+
+    const page = response.data.records as
+      | Array<{
+          uri?: string;
+          cid?: string;
+          value?: Record<string, unknown>;
+        }>
+      | undefined;
+
+    if (page?.length) {
+      for (const record of page) {
+        if (typeof record.uri !== "string") {
+          continue;
+        }
+
+        records.push({
+          uri: record.uri,
+          cid: typeof record.cid === "string" ? record.cid : undefined,
+          value: record.value ?? {},
+        });
       }
-    );
+    }
 
-    const connection = response.appGainforestDwcOccurrence;
-    records.push(
-      ...connection.edges.map((edge) => mapOccurrenceNodeToRawRecord(edge.node))
-    );
-
-    cursor = connection.pageInfo.hasNextPage
-      ? connection.pageInfo.endCursor
-      : null;
+    cursor = response.data.cursor ?? undefined;
   } while (cursor);
 
   return records;
+};
+
+const parseAtUri = (uri: string): { did: string; collection: string; rkey: string } | null => {
+  if (!uri.startsWith("at://")) {
+    return null;
+  }
+
+  const rest = uri.slice(5);
+  const [did, collection, rkey] = rest.split("/");
+
+  if (!did || !collection || !rkey) {
+    return null;
+  }
+
+  return { did, collection, rkey };
+};
+
+const fetchPdsOccurrenceByUri = async (
+  agent: Agent,
+  uri: string,
+): Promise<RawOccurrenceRecord | null> => {
+  const parsed = parseAtUri(uri);
+  if (!parsed || parsed.collection !== OCCURRENCE_COLLECTION) {
+    if (process.env.NODE_ENV === "development") {
+      console.warn("[GG preview] tree-uri rejected:", uri, parsed);
+    }
+    return null;
+  }
+
+  try {
+    const response = await agent.com.atproto.repo.getRecord({
+      repo: parsed.did,
+      collection: parsed.collection,
+      rkey: parsed.rkey,
+    });
+
+    return {
+      uri: response.data.uri,
+      cid: response.data.cid,
+      value: (response.data.value as Record<string, unknown>) ?? {},
+    };
+  } catch (err) {
+    if (process.env.NODE_ENV === "development") {
+      console.warn("[GG preview] fetchPdsOccurrenceByUri failed:", uri, err);
+    }
+    return null;
+  }
+};
+
+const hasCoordinates = (value: RawOccurrenceValue): boolean => {
+  const lat =
+    typeof value.decimalLatitude === "string"
+      ? parseFloat(value.decimalLatitude)
+      : typeof value.decimalLatitude === "number"
+        ? value.decimalLatitude
+        : null;
+  const lon =
+    typeof value.decimalLongitude === "string"
+      ? parseFloat(value.decimalLongitude)
+      : typeof value.decimalLongitude === "number"
+        ? value.decimalLongitude
+        : null;
+
+  return lat !== null && lon !== null && !Number.isNaN(lat) && !Number.isNaN(lon);
+};
+
+const hasDatasetRef = (value: RawOccurrenceValue): boolean =>
+  typeof value.datasetRef === "string" && value.datasetRef.trim().length > 0;
+
+const isLegacyBumicertsTreeOccurrence = (
+  record: RawOccurrenceRecord,
+  measurementIndex: MeasurementsByOccurrence,
+  multimediaIndex: MultimediaByOccurrence,
+): boolean => {
+  if (!hasDatasetRef(record.value)) {
+    return false;
+  }
+
+  return (
+    measurementIndex.has(record.uri) ||
+    hasTreePhotos(multimediaIndex, record.uri)
+  );
+};
+
+const hasTreePhotos = (
+  multimediaIndex: MultimediaByOccurrence,
+  occurrenceUri: string,
+): boolean => {
+  const media = multimediaIndex.get(occurrenceUri);
+  if (!media) {
+    return false;
+  }
+
+  return Object.values(media).some(
+    (entry) => typeof entry === "string" && entry.trim().length > 0,
+  );
+};
+
+const isMeasuredTreeOccurrence = (
+  record: RawOccurrenceRecord,
+  measurementIndex: MeasurementsByOccurrence,
+  multimediaIndex: MultimediaByOccurrence,
+): boolean => {
+  const value = record.value;
+
+  if (value.basisOfRecord !== "HumanObservation" || !hasCoordinates(value)) {
+    return false;
+  }
+
+  const dynProps = parseDynamicProperties(value.dynamicProperties);
+  if (dynProps?.dataType === "measuredTree" || dynProps?.source === "bumicerts") {
+    return true;
+  }
+
+  return isLegacyBumicertsTreeOccurrence(
+    record,
+    measurementIndex,
+    multimediaIndex,
+  );
+};
+
+const buildTreeFeature = (
+  record: RawOccurrenceRecord,
+  measurementIndex: MeasurementsByOccurrence,
+  multimediaIndex: MultimediaByOccurrence,
+): NormalizedTreeFeature | null => {
+  const v = record.value;
+
+  const lat =
+    typeof v.decimalLatitude === "string"
+      ? parseFloat(v.decimalLatitude)
+      : typeof v.decimalLatitude === "number"
+        ? v.decimalLatitude
+        : null;
+  const lon =
+    typeof v.decimalLongitude === "string"
+      ? parseFloat(v.decimalLongitude)
+      : typeof v.decimalLongitude === "number"
+        ? v.decimalLongitude
+        : null;
+
+  if (lat === null || lon === null || isNaN(lat) || isNaN(lon)) {
+    return null;
+  }
+
+  // Look up AC multimedia records for this occurrence
+  const media = multimediaIndex.get(record.uri) ?? {};
+  const trunkUrl = media.entireOrganism ?? null;
+  const leafUrl = media.leaf ?? null;
+  const barkUrl = media.bark ?? null;
+
+  // Extract original S3/Kobo URLs from associatedMedia (pipe-delimited)
+  const associatedMedia =
+    typeof v.associatedMedia === "string" ? v.associatedMedia : "";
+  const mediaParts = associatedMedia
+    ? associatedMedia.split("|").map((s) => s.trim()).filter(Boolean)
+    : [];
+
+  // Also check dynamicProperties for original URLs
+  const dynProps = parseDynamicProperties(v.dynamicProperties);
+  const originalAwsUrl = dynProps?.originalAwsUrl ?? mediaParts[0] ?? "";
+  const originalKoboUrl = dynProps?.originalKoboUrl ?? "";
+
+  const scientificName =
+    typeof v.scientificName === "string" ? v.scientificName : "Unknown";
+  const vernacularName =
+    typeof v.vernacularName === "string" ? v.vernacularName : undefined;
+  const eventDate =
+    typeof v.eventDate === "string" ? v.eventDate : undefined;
+
+  // Measurements from index
+  const measurements = measurementIndex.get(record.uri) ?? {};
+  const datasetRef = typeof v.datasetRef === "string" ? v.datasetRef : undefined;
+  const siteRef = typeof v.siteRef === "string" ? v.siteRef : undefined;
+  const treeSource =
+    dynProps?.source === "bumicerts"
+      ? "bumicerts"
+      : dynProps?.dataType === "measuredTree"
+        ? "measuredTree"
+        : "bumicerts-fallback";
+
+  const rawProperties = {
+    lat,
+    lon,
+    occurrenceUri: record.uri,
+    datasetRef,
+    siteRef,
+    treeSource,
+    species: scientificName,
+    commonName: vernacularName,
+    dateMeasured: eventDate,
+    // PDS blob URLs (primary) — map to existing field names for backward compat
+    awsUrl: trunkUrl ?? originalAwsUrl,
+    koboUrl: originalKoboUrl,
+    leafAwsUrl: leafUrl ?? undefined,
+    leafKoboUrl: undefined,
+    barkAwsUrl: barkUrl ?? "",
+    barkKoboUrl: "",
+    // Measurements
+    DBH: measurements.dbh,
+    Height: measurements.height,
+  };
+
+  const species =
+    getTreeSpeciesName(rawProperties)?.trim() ?? scientificName;
+
+  return {
+    type: "Feature",
+    id: record.uri,
+    geometry: {
+      type: "Point",
+      coordinates: [lon, lat],
+    },
+    properties: {
+      ...rawProperties,
+      species,
+      type: "measured-tree",
+    },
+  };
 };
 
 // ── Main fetcher ───────────────────────────────────────────────────────────────
@@ -209,116 +497,111 @@ const fetchMeasuredTreeOccurrenceRecords = async (
 export const fetchMeasuredTreeOccurrences = async (
   did: string,
 ): Promise<MeasuredTreesGeoJSON | null> => {
+  const { datasetRef, treeUri } = usePreviewStore.getState();
+  const shouldFetchPdsPreviewOccurrences =
+    datasetRef !== null || treeUri !== null;
+
+  // Resolve the org DID to its home PDS. Records for Bumicerts-certified orgs
+  // live on PDSes other than the default (e.g. gainforest.id), so using the
+  // singleton agent would silently return RecordNotFound.
+  const pdsEndpoint = await resolvePdsEndpoint(did);
+  const agent = new Agent(pdsEndpoint);
+
+  // For a selected tree URI the owning DID may differ from the project DID
+  // (cross-org preview). Resolve separately so getRecord hits the right PDS.
+  const selectedTreeAgentPromise: Promise<Agent | null> = treeUri
+    ? (async () => {
+        const parsed = parseAtUri(treeUri);
+        if (!parsed) return null;
+        if (parsed.did === did) return agent;
+        const endpoint = await resolvePdsEndpoint(parsed.did);
+        return new Agent(endpoint);
+      })()
+    : Promise.resolve(null);
+
+  const selectedTreeAgent = await selectedTreeAgentPromise;
+
   // Fetch measurements, AC multimedia, and measured-tree occurrences in parallel.
-  const [measurementIndex, multimediaIndex, occurrences] = await Promise.all([
-    fetchMeasurementIndex(did),
+  const [
+    measurementIndex,
+    multimediaIndex,
+    hyperindexOccurrences,
+    pdsOccurrences,
+    selectedPdsOccurrence,
+  ] = await Promise.all([
+    fetchMeasurementIndex(agent, did),
     fetchMultimediaByOccurrence(did),
     fetchMeasuredTreeOccurrenceRecords(did),
+    shouldFetchPdsPreviewOccurrences
+      ? fetchPdsOccurrenceRecords(agent, did)
+      : Promise.resolve([]),
+    treeUri && selectedTreeAgent
+      ? fetchPdsOccurrenceByUri(selectedTreeAgent, treeUri)
+      : Promise.resolve(null),
   ]);
 
-  // Filter to measured tree occurrences
-  const measuredTreeRecords = occurrences.filter((record) => {
-    const v = record.value;
-    if (
-      typeof v.basisOfRecord !== "string" ||
-      v.basisOfRecord !== "HumanObservation"
-    ) {
-      return false;
-    }
-    const dynProps = parseDynamicProperties(v.dynamicProperties);
-    return dynProps?.dataType === "measuredTree";
-  });
+  const occurrencesByUri = new Map<string, RawOccurrenceRecord>();
+  for (const occurrence of hyperindexOccurrences) {
+    occurrencesByUri.set(occurrence.uri, occurrence);
+  }
+  for (const occurrence of pdsOccurrences) {
+    occurrencesByUri.set(occurrence.uri, occurrence);
+  }
+  if (selectedPdsOccurrence) {
+    occurrencesByUri.set(selectedPdsOccurrence.uri, selectedPdsOccurrence);
+  }
+  const occurrences = [...occurrencesByUri.values()];
 
-  if (measuredTreeRecords.length === 0) return null;
+  // Filter to measured tree occurrences, including Bumicerts fallback detection
+  const measuredTreeRecords = occurrences.filter((record) =>
+    isMeasuredTreeOccurrence(record, measurementIndex, multimediaIndex),
+  );
 
-  // Map to NormalizedTreeFeature
-  const features: NormalizedTreeFeature[] = measuredTreeRecords
-    .map((record, index) => {
-      const v = record.value;
+  // When the user passes an explicit tree-uri, trust it: include the directly
+  // fetched record even if it fails the measured-tree heuristics (e.g. legacy
+  // Bumicerts trees without dynamicProperties marker, datasetRef, or linked
+  // measurements/photos). Still gate on the basic observation+coordinates
+  // invariant so we never admit non-tree PDS records.
+  const forcedSelected =
+    selectedPdsOccurrence &&
+    selectedPdsOccurrence.value.basisOfRecord === "HumanObservation" &&
+    hasCoordinates(selectedPdsOccurrence.value) &&
+    !measuredTreeRecords.some((r) => r.uri === selectedPdsOccurrence.uri)
+      ? selectedPdsOccurrence
+      : null;
 
-      const lat =
-        typeof v.decimalLatitude === "string"
-          ? parseFloat(v.decimalLatitude)
-          : typeof v.decimalLatitude === "number"
-            ? v.decimalLatitude
-            : null;
-      const lon =
-        typeof v.decimalLongitude === "string"
-          ? parseFloat(v.decimalLongitude)
-          : typeof v.decimalLongitude === "number"
-            ? v.decimalLongitude
-            : null;
+  const recordsToBuild = forcedSelected
+    ? [...measuredTreeRecords, forcedSelected]
+    : measuredTreeRecords;
 
-      if (lat === null || lon === null || isNaN(lat) || isNaN(lon)) {
-        return null;
-      }
+  if (process.env.NODE_ENV === "development" && treeUri) {
+    console.info("[GG preview] tree-uri requested:", treeUri);
+    console.info(
+      "[GG preview] PDS fetch result:",
+      selectedPdsOccurrence ? "found" : "null",
+    );
+    console.info(
+      "[GG preview] force-including selected (not in measured set):",
+      !!forcedSelected,
+    );
+  }
 
-      // Look up AC multimedia records for this occurrence
-      const media = multimediaIndex.get(record.uri) ?? {};
-      const trunkUrl = media.entireOrganism ?? null;
-      const leafUrl = media.leaf ?? null;
-      const barkUrl = media.bark ?? null;
+  if (recordsToBuild.length === 0) return null;
 
-      // Extract original S3/Kobo URLs from associatedMedia (pipe-delimited)
-      const associatedMedia =
-        typeof v.associatedMedia === "string" ? v.associatedMedia : "";
-      const mediaParts = associatedMedia
-        ? associatedMedia.split("|").map((s) => s.trim()).filter(Boolean)
-        : [];
-
-      // Also check dynamicProperties for original URLs
-      const dynProps = parseDynamicProperties(v.dynamicProperties);
-      const originalAwsUrl = dynProps?.originalAwsUrl ?? mediaParts[0] ?? "";
-      const originalKoboUrl = dynProps?.originalKoboUrl ?? "";
-
-      const scientificName =
-        typeof v.scientificName === "string" ? v.scientificName : "Unknown";
-      const vernacularName =
-        typeof v.vernacularName === "string" ? v.vernacularName : undefined;
-      const eventDate =
-        typeof v.eventDate === "string" ? v.eventDate : undefined;
-
-      // Measurements from index
-      const measurements = measurementIndex.get(record.uri) ?? {};
-
-      const rawProperties = {
-        lat,
-        lon,
-        species: scientificName,
-        commonName: vernacularName,
-        dateMeasured: eventDate,
-        // PDS blob URLs (primary) — map to existing field names for backward compat
-        awsUrl: trunkUrl ?? originalAwsUrl,
-        koboUrl: originalKoboUrl,
-        leafAwsUrl: leafUrl ?? undefined,
-        leafKoboUrl: undefined,
-        barkAwsUrl: barkUrl ?? "",
-        barkKoboUrl: "",
-        // Measurements
-        DBH: measurements.dbh,
-        Height: measurements.height,
-      };
-
-      const species =
-        getTreeSpeciesName(rawProperties)?.trim() ?? scientificName;
-
-      const feature: NormalizedTreeFeature = {
-        type: "Feature",
-        id: index,
-        geometry: {
-          type: "Point",
-          coordinates: [lon, lat],
-        },
-        properties: {
-          ...rawProperties,
-          species,
-          type: "measured-tree",
-        },
-      };
-
-      return feature;
-    })
+  const features = recordsToBuild
+    .map((record) =>
+      buildTreeFeature(record, measurementIndex, multimediaIndex),
+    )
     .filter((f): f is NormalizedTreeFeature => f !== null);
+
+  if (process.env.NODE_ENV === "development" && treeUri) {
+    const hit = features.find((f) => f.properties.occurrenceUri === treeUri);
+    console.info(
+      "[GG preview] tree in feature set:",
+      !!hit,
+      hit?.properties.treeSource,
+    );
+  }
 
   if (features.length === 0) return null;
 

--- a/src/app/embed/[projectId]/page.tsx
+++ b/src/app/embed/[projectId]/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Suspense, use } from "react";
+import { useSearchParams } from "next/navigation";
+import HoveredTreeOverlay from "@/app/(map-routes)/(main)/_components/HoveredTreeOverlay";
+import Map from "@/app/(map-routes)/(main)/_components/Map";
+import useStoreUrlSync from "@/app/(map-routes)/(main)/_features/navigation/use-store-url-sync";
+
+function EmbedProjectMap({ projectId }: { projectId: string }) {
+  const queryParams = useSearchParams();
+  const decodedProjectId = decodeURIComponent(projectId);
+
+  useStoreUrlSync(queryParams, {
+    projectId: decodedProjectId,
+    embed: true,
+  });
+
+  return (
+    <div className="relative flex h-screen w-full flex-col bg-background">
+      <Map />
+      <HoveredTreeOverlay />
+    </div>
+  );
+}
+
+export default function EmbedProjectPage({
+  params,
+}: {
+  params: Promise<{ projectId: string }>;
+}) {
+  const { projectId } = use(params);
+
+  return (
+    <Suspense>
+      <EmbedProjectMap projectId={projectId} />
+    </Suspense>
+  );
+}

--- a/src/lib/atproto/ac-multimedia.ts
+++ b/src/lib/atproto/ac-multimedia.ts
@@ -1,5 +1,5 @@
-import { PDS_ENDPOINT } from "@/config/atproto";
 import { extractCid, buildBlobUrl } from "@/lib/atproto/extract-cid";
+import { resolvePdsEndpoint } from "@/lib/atproto/resolve-pds";
 import { hyperindexClient } from "@/lib/hyperindex/client";
 import { MULTIMEDIA_BY_DID } from "@/lib/hyperindex/queries";
 import type { Connection, HiAcMultimedia } from "@/lib/hyperindex/types";
@@ -68,6 +68,7 @@ export const fetchMultimediaIndex = async (
   did: string
 ): Promise<MultimediaIndex> => {
   const index: MultimediaIndex = new Map();
+  const pdsEndpoint = await resolvePdsEndpoint(did);
 
   for (const record of await fetchAllMultimedia(did)) {
     const occurrenceRef =
@@ -78,7 +79,7 @@ export const fetchMultimediaIndex = async (
     if (!cid) continue;
 
     if (!index.has(occurrenceRef)) {
-      index.set(occurrenceRef, buildBlobUrl(PDS_ENDPOINT, did, cid));
+      index.set(occurrenceRef, buildBlobUrl(pdsEndpoint, did, cid));
     }
   }
 
@@ -95,6 +96,7 @@ export const fetchMultimediaByOccurrence = async (
   did: string
 ): Promise<MultimediaByOccurrence> => {
   const index: MultimediaByOccurrence = new Map();
+  const pdsEndpoint = await resolvePdsEndpoint(did);
 
   for (const record of await fetchAllMultimedia(did)) {
     const occurrenceRef =
@@ -108,7 +110,7 @@ export const fetchMultimediaByOccurrence = async (
     const cid = extractCid(record.file?.ref);
     if (!cid) continue;
 
-    const blobUrl = buildBlobUrl(PDS_ENDPOINT, did, cid);
+    const blobUrl = buildBlobUrl(pdsEndpoint, did, cid);
     const existing = index.get(occurrenceRef) ?? {};
     index.set(occurrenceRef, { ...existing, [subjectPart]: blobUrl });
   }

--- a/src/lib/atproto/resolve-pds.ts
+++ b/src/lib/atproto/resolve-pds.ts
@@ -1,0 +1,64 @@
+import { PDS_ENDPOINT } from "@/config/atproto";
+
+const cache = new Map<string, Promise<string>>();
+
+type PlcService = {
+  id?: string;
+  type?: string;
+  serviceEndpoint?: string;
+};
+
+/**
+ * Resolve a DID to its home PDS endpoint.
+ *
+ * The app's singleton `ClimateAIAgent` points at a fixed PDS, but records for
+ * external orgs (e.g. Bumicerts-certified trees on `gainforest.id`) live on
+ * different PDSes. Using the wrong endpoint makes `getRecord`/`listRecords`
+ * return RecordNotFound and produces silent empty fetches.
+ *
+ * This helper looks up the DID document and returns the AtprotoPersonalDataServer
+ * service endpoint. Falls back to the configured default on any failure.
+ */
+export const resolvePdsEndpoint = async (did: string): Promise<string> => {
+  const cached = cache.get(did);
+  if (cached) return cached;
+
+  const promise = (async (): Promise<string> => {
+    try {
+      if (did.startsWith("did:plc:")) {
+        const res = await fetch(
+          `https://plc.directory/${encodeURIComponent(did)}`,
+        );
+        if (!res.ok) {
+          throw new Error(`plc.directory ${res.status}`);
+        }
+        const doc = (await res.json()) as { service?: PlcService[] };
+        const services = Array.isArray(doc.service) ? doc.service : [];
+        const pds = services.find(
+          (s) =>
+            s.type === "AtprotoPersonalDataServer" &&
+            typeof s.serviceEndpoint === "string",
+        );
+        if (pds?.serviceEndpoint) {
+          if (process.env.NODE_ENV === "development") {
+            console.info(
+              "[GG] resolved PDS for",
+              did,
+              "→",
+              pds.serviceEndpoint,
+            );
+          }
+          return pds.serviceEndpoint;
+        }
+      }
+    } catch (err) {
+      if (process.env.NODE_ENV === "development") {
+        console.warn("[GG] PDS resolution failed for", did, err);
+      }
+    }
+    return PDS_ENDPOINT;
+  })();
+
+  cache.set(did, promise);
+  return promise;
+};

--- a/src/lib/hyperindex/queries.ts
+++ b/src/lib/hyperindex/queries.ts
@@ -237,6 +237,7 @@ export const OCCURRENCES_BY_DID = gql`
           eventDate
           occurrenceID
           dynamicProperties
+          datasetRef
           conservationStatus
           plantTraits
           imageEvidence
@@ -343,6 +344,7 @@ export const OCCURRENCES_BY_DID_WITH_DYNAMIC = gql`
           decimalLongitude
           eventDate
           dynamicProperties
+          datasetRef
           associatedMedia
           basisOfRecord
         }

--- a/src/lib/hyperindex/types.ts
+++ b/src/lib/hyperindex/types.ts
@@ -194,6 +194,7 @@ export type HiDwcOccurrence = {
   associatedMedia?: string;
   // Extended
   dynamicProperties?: string;
+  datasetRef?: string;
   conservationStatus?: unknown;
   plantTraits?: unknown;
   // Linkage


### PR DESCRIPTION
## Summary

Ships the `/embed/[did]` route that Bumicerts' Tree Manager embeds to preview a selected tree, and makes Green Globe able to render data for orgs whose records live on PDSes other than the hardcoded default (e.g. `gainforest.id`).

- **Embed route & preview state** — `/embed/[projectId]` page, preview store driven by `tree-uri` / `dataset-ref` URL params, selected-tree highlight, zoom-to-tree, and dataset filtering.
- **Cross-PDS routing** — `resolvePdsEndpoint(did)` resolves the org's home PDS via `plc.directory` (cached per-DID) and a per-DID `Agent` is used for occurrence / measurement / site shapefile / AC multimedia blob fetches. Previously every PDS call hit the singleton `ClimateAIAgent` and silently returned `RecordNotFound` for any off-host record.
- **Explicit-URI override** — when `tree-uri` is present, the directly-fetched selected occurrence is always added as a feature, bypassing the measured-tree detection heuristics. Legacy Bumicerts records (no `dynamicProperties` marker, no linked measurements / photos) now render.
- **Graceful hyperindex degradation** — the measured-tree occurrence query is wrapped in a try/catch so schema drift on the deployed indexer falls back to PDS `listRecords` instead of surfacing as an error.
- **Mapbox hover guard** — `setFeatureState` calls in `useHoveredTreeInfo` now skip null/undefined ids, which the clustered trees source can emit for string-keyed features.
- **`next/image` allowlist** — path-scoped `remotePatterns` entry for `/xrpc/com.atproto.sync.getBlob` so blobs from any ATProto PDS can be served through the optimizer.
- **E2E fixtures** — `network.ts` and `error-routes.ts` updated to match the renamed `OccurrencesByDid` query, and the "failing measured trees endpoint" scenario now also fails the measurement `listRecords` XRPC so the error UX is still exercised end-to-end after the hyperindex fallback was added.

## Test plan
- [x] `bun run lint` — no new warnings in touched files
- [x] `bun run build` — passes
- [x] `bun run test:e2e:headless` — 12/12 scenarios pass (confirmed stable across multiple runs; two pre-existing flaky scenarios occasionally surface but are unrelated to these changes)
- [ ] Manual: open `/embed/[did]?tree-uri=at://...&dataset-ref=at://...` for a Bumicerts-certified tree — confirm pink dot renders, selected tree highlighted, map zooms to ~500m around the tree, hover + tree photos load
- [ ] Manual: open `/embed/[did]` without any params — org's trees render normally
- [ ] Manual: open `/embed/[did]?tree-uri=garbage` — no crash, dev console warns
- [ ] Manual: regression — open the root `/` globe, navigate into an existing climateai.org-hosted project — photos still load