### PR TITLE
feat(map): replace pulsing overlay with right-to-left skeleton loader

### DIFF
--- a/src/app/(map-routes)/(main)/_components/Map/TreesLoadingOverlay.tsx
+++ b/src/app/(map-routes)/(main)/_components/Map/TreesLoadingOverlay.tsx
@@ -88,20 +88,16 @@ const TreesLoadingOverlay = () => {
         </clipPath>
       </defs>
 
-      <rect
-        width="100%"
-        height="100%"
-        fill="rgba(255,255,255,0.07)"
-        clipPath="url(#trees-loading-clip)"
-      />
-
-      <rect
-        width="100%"
-        height="100%"
-        fill="url(#trees-shimmer-grad)"
-        clipPath="url(#trees-loading-clip)"
-        className="trees-shimmer-sweep"
-      />
+      {/* clipPath on the group so the polygon clip is fixed while the gradient sweeps inside */}
+      <g clipPath="url(#trees-loading-clip)">
+        <rect width="100%" height="100%" fill="rgba(255,255,255,0.07)" />
+        <rect
+          width="100%"
+          height="100%"
+          fill="url(#trees-shimmer-grad)"
+          className="trees-shimmer-sweep"
+        />
+      </g>
     </svg>
   );
 };

--- a/src/app/(map-routes)/(main)/_components/Map/TreesLoadingOverlay.tsx
+++ b/src/app/(map-routes)/(main)/_components/Map/TreesLoadingOverlay.tsx
@@ -1,31 +1,38 @@
 "use client";
-import { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import useMapStore from "./store";
 import useProjectOverlayStore from "../ProjectOverlay/store";
-import bbox from "@turf/bbox";
 import type { Map as MapboxMap } from "mapbox-gl";
 import type { ProjectPolygonAPIResponse } from "../ProjectOverlay/store/types";
 
-type ScreenBounds = { top: number; left: number; width: number; height: number };
-
-const computeScreenBounds = (
+const computeClipRings = (
   map: MapboxMap,
   polygon: ProjectPolygonAPIResponse
-): ScreenBounds | null => {
-  const [minLng, minLat, maxLng, maxLat] = bbox(
-    polygon as unknown as GeoJSON.FeatureCollection
-  );
-  const sw = map.project([minLng, minLat]);
-  const ne = map.project([maxLng, maxLat]);
+): string[] => {
+  const collection = polygon as unknown as GeoJSON.FeatureCollection;
   const rect = map.getContainer().getBoundingClientRect();
+  const rings: string[] = [];
 
-  const top = rect.top + Math.min(sw.y, ne.y);
-  const left = rect.left + Math.min(sw.x, ne.x);
-  const width = Math.abs(ne.x - sw.x);
-  const height = Math.abs(ne.y - sw.y);
+  const projectRing = (ring: number[][]): string =>
+    ring
+      .map(([lng, lat]) => {
+        const { x, y } = map.project([lng, lat]);
+        return `${rect.left + x},${rect.top + y}`;
+      })
+      .join(" ");
 
-  if (width <= 0 || height <= 0) return null;
-  return { top, left, width, height };
+  for (const feature of collection.features ?? []) {
+    const geo = feature.geometry as GeoJSON.Geometry;
+    if (geo.type === "Polygon") {
+      rings.push(projectRing((geo as GeoJSON.Polygon).coordinates[0]));
+    } else if (geo.type === "MultiPolygon") {
+      for (const poly of (geo as GeoJSON.MultiPolygon).coordinates) {
+        rings.push(projectRing(poly[0]));
+      }
+    }
+  }
+
+  return rings;
 };
 
 const TreesLoadingOverlay = () => {
@@ -34,7 +41,7 @@ const TreesLoadingOverlay = () => {
   const highlightedPolygon = useMapStore((s) => s.highlightedPolygon);
   const treesAsync = useProjectOverlayStore((s) => s.treesAsync);
   const projectId = useProjectOverlayStore((s) => s.projectId);
-  const [bounds, setBounds] = useState<ScreenBounds | null>(null);
+  const [rings, setRings] = useState<string[]>([]);
 
   const isLoading =
     projectId !== undefined &&
@@ -43,10 +50,10 @@ const TreesLoadingOverlay = () => {
   const update = useCallback(() => {
     const map = mapRef?.current;
     if (!map || !highlightedPolygon) {
-      setBounds(null);
+      setRings([]);
       return;
     }
-    setBounds(computeScreenBounds(map, highlightedPolygon));
+    setRings(computeClipRings(map, highlightedPolygon));
   }, [mapRef, highlightedPolygon]);
 
   useEffect(() => {
@@ -59,15 +66,43 @@ const TreesLoadingOverlay = () => {
     };
   }, [mapLoaded, mapRef, update]);
 
-  if (!isLoading || !bounds) return null;
+  if (!isLoading || rings.length === 0) return null;
 
   return (
-    <div
-      className="pointer-events-none overflow-hidden"
-      style={{ position: "fixed", zIndex: 10, ...bounds }}
+    <svg
+      className="pointer-events-none"
+      style={{ position: "fixed", inset: 0, width: "100vw", height: "100vh", zIndex: 10 }}
     >
-      <div className="trees-loading-shimmer" />
-    </div>
+      <defs>
+        <linearGradient id="trees-shimmer-grad" x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" stopColor="rgba(255,255,255,0)" />
+          <stop offset="40%" stopColor="rgba(255,255,255,0)" />
+          <stop offset="50%" stopColor="rgba(255,255,255,0.22)" />
+          <stop offset="60%" stopColor="rgba(255,255,255,0)" />
+          <stop offset="100%" stopColor="rgba(255,255,255,0)" />
+        </linearGradient>
+        <clipPath id="trees-loading-clip">
+          {rings.map((pts, i) => (
+            <polygon key={i} points={pts} />
+          ))}
+        </clipPath>
+      </defs>
+
+      <rect
+        width="100%"
+        height="100%"
+        fill="rgba(255,255,255,0.07)"
+        clipPath="url(#trees-loading-clip)"
+      />
+
+      <rect
+        width="100%"
+        height="100%"
+        fill="url(#trees-shimmer-grad)"
+        clipPath="url(#trees-loading-clip)"
+        className="trees-shimmer-sweep"
+      />
+    </svg>
   );
 };
 

--- a/src/app/(map-routes)/(main)/_components/Map/TreesLoadingOverlay.tsx
+++ b/src/app/(map-routes)/(main)/_components/Map/TreesLoadingOverlay.tsx
@@ -1,0 +1,74 @@
+"use client";
+import { useEffect, useState, useCallback } from "react";
+import useMapStore from "./store";
+import useProjectOverlayStore from "../ProjectOverlay/store";
+import bbox from "@turf/bbox";
+import type { Map as MapboxMap } from "mapbox-gl";
+import type { ProjectPolygonAPIResponse } from "../ProjectOverlay/store/types";
+
+type ScreenBounds = { top: number; left: number; width: number; height: number };
+
+const computeScreenBounds = (
+  map: MapboxMap,
+  polygon: ProjectPolygonAPIResponse
+): ScreenBounds | null => {
+  const [minLng, minLat, maxLng, maxLat] = bbox(
+    polygon as unknown as GeoJSON.FeatureCollection
+  );
+  const sw = map.project([minLng, minLat]);
+  const ne = map.project([maxLng, maxLat]);
+  const rect = map.getContainer().getBoundingClientRect();
+
+  const top = rect.top + Math.min(sw.y, ne.y);
+  const left = rect.left + Math.min(sw.x, ne.x);
+  const width = Math.abs(ne.x - sw.x);
+  const height = Math.abs(ne.y - sw.y);
+
+  if (width <= 0 || height <= 0) return null;
+  return { top, left, width, height };
+};
+
+const TreesLoadingOverlay = () => {
+  const mapRef = useMapStore((s) => s.mapRef);
+  const mapLoaded = useMapStore((s) => s.mapLoaded);
+  const highlightedPolygon = useMapStore((s) => s.highlightedPolygon);
+  const treesAsync = useProjectOverlayStore((s) => s.treesAsync);
+  const projectId = useProjectOverlayStore((s) => s.projectId);
+  const [bounds, setBounds] = useState<ScreenBounds | null>(null);
+
+  const isLoading =
+    projectId !== undefined &&
+    (!treesAsync || treesAsync._status === "loading");
+
+  const update = useCallback(() => {
+    const map = mapRef?.current;
+    if (!map || !highlightedPolygon) {
+      setBounds(null);
+      return;
+    }
+    setBounds(computeScreenBounds(map, highlightedPolygon));
+  }, [mapRef, highlightedPolygon]);
+
+  useEffect(() => {
+    const map = mapRef?.current;
+    if (!mapLoaded || !map) return;
+    update();
+    map.on("move", update);
+    return () => {
+      map.off("move", update);
+    };
+  }, [mapLoaded, mapRef, update]);
+
+  if (!isLoading || !bounds) return null;
+
+  return (
+    <div
+      className="pointer-events-none overflow-hidden"
+      style={{ position: "fixed", zIndex: 10, ...bounds }}
+    >
+      <div className="trees-loading-shimmer" />
+    </div>
+  );
+};
+
+export default TreesLoadingOverlay;

--- a/src/app/(map-routes)/(main)/_components/Map/hooks/useTreesLoadingOverlay.ts
+++ b/src/app/(map-routes)/(main)/_components/Map/hooks/useTreesLoadingOverlay.ts
@@ -22,26 +22,7 @@ const useTreesLoadingOverlay = () => {
     }
 
     map.setLayoutProperty("treesLoadingFill", "visibility", "visible");
-
-    let rafId: number;
-    let startTime: number | null = null;
-
-    const animate = (timestamp: number) => {
-      if (!startTime) startTime = timestamp;
-      const t = (timestamp - startTime) / 1200;
-      const opacity = 0.105 + 0.075 * Math.sin(t * Math.PI * 2);
-      map.setPaintProperty("treesLoadingFill", "fill-opacity", opacity);
-      rafId = requestAnimationFrame(animate);
-    };
-
-    rafId = requestAnimationFrame(animate);
-
-    return () => {
-      cancelAnimationFrame(rafId);
-      if (map.getLayer("treesLoadingFill")) {
-        map.setLayoutProperty("treesLoadingFill", "visibility", "none");
-      }
-    };
+    map.setPaintProperty("treesLoadingFill", "fill-opacity", 0.08);
   }, [isLoading, mapLoaded, mapRef]);
 };
 

--- a/src/app/(map-routes)/(main)/layout.tsx
+++ b/src/app/(map-routes)/(main)/layout.tsx
@@ -1,6 +1,7 @@
 import HoveredTreeOverlay from "./_components/HoveredTreeOverlay";
 import Map from "./_components/Map";
 import Sidebar from "./_components/Overlay";
+import TreesLoadingOverlay from "./_components/Map/TreesLoadingOverlay";
 
 export default function MapLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -8,6 +9,7 @@ export default function MapLayout({ children }: { children: React.ReactNode }) {
       <Map />
       <Sidebar />
       <HoveredTreeOverlay />
+      <TreesLoadingOverlay />
       {children}
     </div>
   );

--- a/src/app/(map-routes)/_styles/map.css
+++ b/src/app/(map-routes)/_styles/map.css
@@ -15,3 +15,23 @@
 .mapboxgl-popup-tip {
   border-top-color: rgb(255 255 255 / 0.8) !important;
 }
+
+.trees-loading-shimmer {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.0) 20%,
+    rgba(255, 255, 255, 0.18) 50%,
+    rgba(255, 255, 255, 0.0) 80%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  animation: trees-loading-skeleton 1.8s ease-in-out infinite;
+}
+
+@keyframes trees-loading-skeleton {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}

--- a/src/app/(map-routes)/_styles/map.css
+++ b/src/app/(map-routes)/_styles/map.css
@@ -16,22 +16,11 @@
   border-top-color: rgb(255 255 255 / 0.8) !important;
 }
 
-.trees-loading-shimmer {
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgba(255, 255, 255, 0.0) 20%,
-    rgba(255, 255, 255, 0.18) 50%,
-    rgba(255, 255, 255, 0.0) 80%,
-    transparent 100%
-  );
-  background-size: 200% 100%;
-  animation: trees-loading-skeleton 1.8s ease-in-out infinite;
+.trees-shimmer-sweep {
+  animation: trees-shimmer-sweep 1.8s ease-in-out infinite;
 }
 
-@keyframes trees-loading-skeleton {
-  0%   { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
+@keyframes trees-shimmer-sweep {
+  0%   { transform: translateX(100vw); }
+  100% { transform: translateX(-100vw); }
 }


### PR DESCRIPTION
Swaps the RAF-based opacity animation for an HTML skeleton shimmer that sweeps from right to left over the project boundary bounding box while tree data is loading. The Mapbox fill layer remains as a static polygon tint; the CSS animation provides the moving loader effect.