### PR TITLE
fix(map): keep measured tree hovers on PDS when Hyperindex drifts

### DIFF
--- a/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/measured-trees.ts
+++ b/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/measured-trees.ts
@@ -193,22 +193,32 @@ export const getTreeDateOfMeasurement = (tree: TreeFeature["properties"]) => {
 const isPdsBlobUrl = (url: string): boolean =>
   url.includes("com.atproto.sync.getBlob");
 
+const appendUniquePhoto = (result: string[], url: string | undefined) => {
+  if (!url || url.trim() === "" || result.includes(url)) {
+    return;
+  }
+
+  result.push(url);
+};
+
 export const getTreePhotos = (
   tree: TreeFeature["properties"],
   activeProject: string,
   treeID: string
 ) => {
-  const result = [];
+  const result: string[] = [];
   if (tree?.tree_photo) {
     return [tree?.tree_photo];
   }
 
-  // PDS blob URL detection: if awsUrl is a PDS blob URL, use it directly
-  // (no S3 fallback needed — the blob is already on the PDS)
-  if (tree?.awsUrl && isPdsBlobUrl(tree.awsUrl)) {
-    result.push(tree.awsUrl);
-    if (tree?.leafAwsUrl) result.push(tree.leafAwsUrl);
-    if (tree?.barkAwsUrl) result.push(tree.barkAwsUrl);
+  // Prefer any PDS blob-backed tree angle before falling back to legacy URLs.
+  const primaryPdsPhoto = [tree?.awsUrl, tree?.leafAwsUrl, tree?.barkAwsUrl].find(
+    (url): url is string => typeof url === "string" && isPdsBlobUrl(url)
+  );
+  if (primaryPdsPhoto) {
+    appendUniquePhoto(result, primaryPdsPhoto);
+    appendUniquePhoto(result, tree?.leafAwsUrl);
+    appendUniquePhoto(result, tree?.barkAwsUrl);
     return result;
   }
 
@@ -224,21 +234,21 @@ export const getTreePhotos = (
     }
   }
   if (tree?.awsUrl) {
-    result.push(tree?.awsUrl);
+    appendUniquePhoto(result, tree?.awsUrl);
   } else if (tree?.koboUrl) {
-    result.push(tree?.koboUrl);
+    appendUniquePhoto(result, tree?.koboUrl);
   }
 
   if (tree?.leafAwsUrl) {
-    result.push(tree?.leafAwsUrl);
+    appendUniquePhoto(result, tree?.leafAwsUrl);
   } else if (tree?.leafKoboUrl) {
-    result.push(tree?.leafKoboUrl);
+    appendUniquePhoto(result, tree?.leafKoboUrl);
   }
 
   if (tree?.barkAwsUrl) {
-    result.push(tree?.barkAwsUrl);
+    appendUniquePhoto(result, tree?.barkAwsUrl);
   } else if (tree?.barkKoboUrl) {
-    result.push(tree?.barkKoboUrl);
+    appendUniquePhoto(result, tree?.barkKoboUrl);
   }
   if (result.length == 0) {
     result.push(

--- a/src/app/(map-routes)/(main)/_hooks/use-organization-measured-trees.ts
+++ b/src/app/(map-routes)/(main)/_hooks/use-organization-measured-trees.ts
@@ -434,6 +434,7 @@ const buildTreeFeature = (
     typeof v.vernacularName === "string" ? v.vernacularName : undefined;
   const eventDate =
     typeof v.eventDate === "string" ? v.eventDate : undefined;
+  const primaryPhotoUrl = trunkUrl ?? leafUrl ?? barkUrl ?? originalAwsUrl;
 
   // Measurements from index
   const measurements = measurementIndex.get(record.uri) ?? {};
@@ -456,8 +457,8 @@ const buildTreeFeature = (
     species: scientificName,
     commonName: vernacularName,
     dateMeasured: eventDate,
-    // PDS blob URLs (primary) — map to existing field names for backward compat
-    awsUrl: trunkUrl ?? originalAwsUrl,
+    // Prefer a PDS blob-backed tree angle before falling back to legacy URLs.
+    awsUrl: primaryPhotoUrl,
     koboUrl: originalKoboUrl,
     leafAwsUrl: leafUrl ?? undefined,
     leafKoboUrl: undefined,

--- a/src/app/(map-routes)/(main)/_hooks/use-organization-measured-trees.ts
+++ b/src/app/(map-routes)/(main)/_hooks/use-organization-measured-trees.ts
@@ -49,6 +49,11 @@ type OccurrenceResponse = {
   appGainforestDwcOccurrence: Connection<HiDwcOccurrence>;
 };
 
+type HyperindexOccurrenceFetchResult = {
+  records: RawOccurrenceRecord[];
+  failed: boolean;
+};
+
 // ── Dynamic properties ─────────────────────────────────────────────────────────
 
 type ParsedDynamicProperties = {
@@ -171,14 +176,12 @@ const mapOccurrenceNodeToRawRecord = (
     dynamicProperties: node.dynamicProperties,
     associatedMedia: node.associatedMedia,
     eventDate: node.eventDate,
-    siteRef: node.siteRef,
-    datasetRef: node.datasetRef,
   },
 });
 
 const fetchMeasuredTreeOccurrenceRecords = async (
   did: string,
-): Promise<RawOccurrenceRecord[]> => {
+): Promise<HyperindexOccurrenceFetchResult> => {
   const records: RawOccurrenceRecord[] = [];
   let cursor: string | null = null;
 
@@ -205,20 +208,20 @@ const fetchMeasuredTreeOccurrenceRecords = async (
         ? connection.pageInfo.endCursor
         : null;
     } while (cursor);
+
+    return { records, failed: false };
   } catch (err) {
     // Hyperindex schema may lag the PDS (e.g. new fields not yet indexed).
-    // Degrade gracefully — the PDS listRecords fetch below still surfaces
-    // the data needed to render the tree.
+    // Degrade gracefully by letting the caller decide whether to fall back to
+    // the source-of-truth PDS occurrence records.
     if (process.env.NODE_ENV === "development") {
       console.warn(
         "[GG] hyperindex occurrences fetch failed, falling back to PDS:",
         err,
       );
     }
-    return [];
+    return { records: [], failed: true };
   }
-
-  return records;
 };
 
 const fetchPdsOccurrenceRecords = async (
@@ -521,27 +524,34 @@ export const fetchMeasuredTreeOccurrences = async (
 
   const selectedTreeAgent = await selectedTreeAgentPromise;
 
+  const previewPdsOccurrencesPromise = shouldFetchPdsPreviewOccurrences
+    ? fetchPdsOccurrenceRecords(agent, did)
+    : Promise.resolve<RawOccurrenceRecord[]>([]);
+
   // Fetch measurements, AC multimedia, and measured-tree occurrences in parallel.
   const [
     measurementIndex,
     multimediaIndex,
-    hyperindexOccurrences,
-    pdsOccurrences,
+    hyperindexOccurrenceResult,
+    previewPdsOccurrences,
     selectedPdsOccurrence,
   ] = await Promise.all([
     fetchMeasurementIndex(agent, did),
     fetchMultimediaByOccurrence(did),
     fetchMeasuredTreeOccurrenceRecords(did),
-    shouldFetchPdsPreviewOccurrences
-      ? fetchPdsOccurrenceRecords(agent, did)
-      : Promise.resolve([]),
+    previewPdsOccurrencesPromise,
     treeUri && selectedTreeAgent
       ? fetchPdsOccurrenceByUri(selectedTreeAgent, treeUri)
       : Promise.resolve(null),
   ]);
 
+  const pdsOccurrences =
+    shouldFetchPdsPreviewOccurrences || !hyperindexOccurrenceResult.failed
+      ? previewPdsOccurrences
+      : await fetchPdsOccurrenceRecords(agent, did);
+
   const occurrencesByUri = new Map<string, RawOccurrenceRecord>();
-  for (const occurrence of hyperindexOccurrences) {
+  for (const occurrence of hyperindexOccurrenceResult.records) {
     occurrencesByUri.set(occurrence.uri, occurrence);
   }
   for (const occurrence of pdsOccurrences) {

--- a/src/lib/hyperindex/queries.ts
+++ b/src/lib/hyperindex/queries.ts
@@ -237,12 +237,14 @@ export const OCCURRENCES_BY_DID = gql`
           eventDate
           occurrenceID
           dynamicProperties
-          datasetRef
-          conservationStatus
-          plantTraits
-          imageEvidence
+          imageEvidence {
+            file {
+              ref
+              mimeType
+              size
+            }
+          }
           associatedMedia
-          siteRef
         }
       }
       totalCount
@@ -344,7 +346,13 @@ export const OCCURRENCES_BY_DID_WITH_DYNAMIC = gql`
           decimalLongitude
           eventDate
           dynamicProperties
-          datasetRef
+          imageEvidence {
+            file {
+              ref
+              mimeType
+              size
+            }
+          }
           associatedMedia
           basisOfRecord
         }

--- a/src/lib/hyperindex/types.ts
+++ b/src/lib/hyperindex/types.ts
@@ -188,19 +188,15 @@ export type HiDwcOccurrence = {
   identifiedBy?: string;
   samplingProtocol?: string;
   // Evidence (embedded blobs — CID refs, not full binary)
-  imageEvidence?: { file?: { ref?: unknown; mimeType?: string } };
+  imageEvidence?: { file?: { ref?: unknown; mimeType?: string; size?: number } };
   audioEvidence?: unknown;
   videoEvidence?: unknown;
   associatedMedia?: string;
   // Extended
   dynamicProperties?: string;
-  datasetRef?: string;
-  conservationStatus?: unknown;
-  plantTraits?: unknown;
-  // Linkage
+  datasetName?: string;
   eventRef?: string;
   eventID?: string;
-  siteRef?: string;
 };
 
 // ── app.gainforest.dwc.measurement ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- align measured-tree Hyperindex occurrence queries and types with the live schema, including nested `imageEvidence.file` blob fields
- fall back to PDS occurrence records in normal project view when Hyperindex occurrence fetches fail, so tree overlays stay on ATProto data instead of dropping to legacy AWS shapefiles
- preserve the existing preview merge behavior while no longer assuming `datasetRef` and `siteRef` are present on Hyperindex occurrence records

## Validation
- `bun run lint`
- `bunx tsc --noEmit`
- `bun run build`