### PR TITLE
fix(map): normalize measured tree event dates

### DIFF
--- a/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/measured-trees.ts
+++ b/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/measured-trees.ts
@@ -3,7 +3,7 @@ import {
   GeoJSONSourceSpecification,
   Map,
 } from "mapbox-gl";
-import dayjs from "dayjs";
+import { formatOccurrenceEventDate } from "@/lib/occurrence-event-date";
 import { TreeFeature } from "../../ProjectOverlay/store/types";
 
 export const treesSource: GeoJSONSourceSpecification = {
@@ -160,27 +160,11 @@ export const getTreeDateOfMeasurement = (tree: TreeFeature["properties"]) => {
   if (tree?.dateOfMeasurement) {
     return tree?.dateOfMeasurement;
   } else if (tree?.datePlanted) {
-    return dayjs(tree?.datePlanted).format("DD/MM/YYYY");
+    return formatOccurrenceEventDate(tree?.datePlanted);
   } else if (tree?.dateMeasured) {
-    return dayjs(tree?.dateMeasured).format("DD/MM/YYYY");
+    return formatOccurrenceEventDate(tree?.dateMeasured);
   } else if (tree["FCD-tree_records-tree_time"]) {
-    function formatDateTime(input: string) {
-      const [datePart, timePart] = input.split(" ");
-      const ddmmyyArr = datePart.split("/");
-      const [day, month] = ddmmyyArr;
-      let [, , year] = ddmmyyArr;
-      year = year.length === 2 ? `20${year}` : year;
-      const isoDateString = `${year}-${month}-${day}T${timePart}:00`;
-      const date = new Date(isoDateString);
-      const formattedDate = date.toLocaleDateString("en-GB", {
-        day: "2-digit",
-        month: "2-digit",
-        year: "numeric",
-      });
-
-      return formattedDate;
-    }
-    return formatDateTime(tree["FCD-tree_records-tree_time"]);
+    return formatOccurrenceEventDate(tree["FCD-tree_records-tree_time"]);
   } else {
     return "unknown";
   }

--- a/src/app/(map-routes)/(main)/_components/ProjectOverlay/Biodiversity/Observations/MeasuredTrees/ExportDialog.tsx
+++ b/src/app/(map-routes)/(main)/_components/ProjectOverlay/Biodiversity/Observations/MeasuredTrees/ExportDialog.tsx
@@ -19,6 +19,7 @@ import { assembleDwca } from "@/lib/gbif/dwca";
 import type { PdsOccurrenceRecord } from "@/lib/gbif/dwca/occurrence-writer";
 import type { PdsMeasurementRecord } from "@/lib/gbif/dwca/measurement-writer";
 import type { DwcaEmlInput } from "@/lib/gbif/dwca/types";
+import { normalizeOccurrenceEventDate } from "@/lib/occurrence-event-date";
 
 interface ExportDialogProps {
   selectedFilter: string;
@@ -126,7 +127,14 @@ const ExportDialog: React.FC<ExportDialogProps> = ({
             kingdom: "Plantae",
             decimalLatitude: tree.lat != null ? String(tree.lat) : undefined,
             decimalLongitude: tree.lon != null ? String(tree.lon) : undefined,
-            eventDate: tree.dateMeasured,
+            eventDate:
+              normalizeOccurrenceEventDate(tree.dateMeasured) ??
+              normalizeOccurrenceEventDate(tree.dateOfMeasurement) ??
+              normalizeOccurrenceEventDate(tree.datePlanted) ??
+              normalizeOccurrenceEventDate(
+                tree["FCD-tree_records-tree_time"],
+              ) ??
+              undefined,
             associatedMedia: mediaUrls || undefined,
           };
         }

--- a/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/ayyoweca-uganda.ts
+++ b/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/ayyoweca-uganda.ts
@@ -1,3 +1,7 @@
+import {
+  formatOccurrenceEventDate,
+  normalizeOccurrenceEventDate,
+} from "@/lib/occurrence-event-date";
 import { NormalizedTreeFeature } from "./types";
 
 export type GFTreeProperties = {
@@ -72,14 +76,14 @@ export const convertFromGFTreeFeatureToNormalizedTreeFeature = (
       species: feature.properties.taxonomy?.species ?? "",
       commonName: feature.properties.taxonomy?.common_name ?? "",
       dateMeasured: feature.properties.measurements_in_cm?.date_measured
-        ? new Date(
-            feature.properties.measurements_in_cm.date_measured
-          ).toLocaleDateString("en-GB")
+        ? normalizeOccurrenceEventDate(
+            feature.properties.measurements_in_cm.date_measured,
+          ) ?? feature.properties.measurements_in_cm.date_measured
         : undefined,
       dateOfMeasurement: feature.properties.measurements_in_cm?.date_measured
-        ? new Date(
-            feature.properties.measurements_in_cm.date_measured
-          ).toLocaleDateString("en-GB")
+        ? formatOccurrenceEventDate(
+            feature.properties.measurements_in_cm.date_measured,
+          )
         : undefined,
       datePlanted: feature.properties.date_planted,
       "FCD-tree_records-tree_time": feature.properties.date_planted,

--- a/src/app/(map-routes)/(main)/_hooks/use-organization-measured-trees.ts
+++ b/src/app/(map-routes)/(main)/_hooks/use-organization-measured-trees.ts
@@ -3,6 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Agent } from "@atproto/api";
 import { resolvePdsEndpoint } from "@/lib/atproto/resolve-pds";
+import { normalizeOccurrenceEventDate } from "@/lib/occurrence-event-date";
 import type {
   MeasuredTreesGeoJSON,
   NormalizedTreeFeature,
@@ -434,6 +435,7 @@ const buildTreeFeature = (
     typeof v.vernacularName === "string" ? v.vernacularName : undefined;
   const eventDate =
     typeof v.eventDate === "string" ? v.eventDate : undefined;
+  const normalizedEventDate = normalizeOccurrenceEventDate(eventDate) ?? eventDate;
   const primaryPhotoUrl = trunkUrl ?? leafUrl ?? barkUrl ?? originalAwsUrl;
 
   // Measurements from index
@@ -456,7 +458,7 @@ const buildTreeFeature = (
     treeSource,
     species: scientificName,
     commonName: vernacularName,
-    dateMeasured: eventDate,
+    dateMeasured: normalizedEventDate,
     // Prefer a PDS blob-backed tree angle before falling back to legacy URLs.
     awsUrl: primaryPhotoUrl,
     koboUrl: originalKoboUrl,

--- a/src/lib/occurrence-event-date.test.ts
+++ b/src/lib/occurrence-event-date.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatOccurrenceEventDate,
+  normalizeOccurrenceEventDate,
+  parseOccurrenceEventDate,
+} from "./occurrence-event-date";
+
+describe("parseOccurrenceEventDate", () => {
+  it("parses ISO dates without changing the calendar day", () => {
+    expect(parseOccurrenceEventDate("2022-02-11")).toEqual({
+      raw: "2022-02-11",
+      display: "11/02/2022",
+      iso: "2022-02-11",
+      kind: "iso-date",
+    });
+  });
+
+  it("parses ISO datetimes and keeps the encoded date", () => {
+    expect(parseOccurrenceEventDate("2022-02-11T23:45:00Z")).toEqual({
+      raw: "2022-02-11T23:45:00Z",
+      display: "11/02/2022",
+      iso: "2022-02-11",
+      kind: "iso-datetime",
+    });
+  });
+
+  it("parses day-first slash datetimes from legacy measured-tree data", () => {
+    expect(parseOccurrenceEventDate("30/10/22 12:09")).toEqual({
+      raw: "30/10/22 12:09",
+      display: "30/10/2022",
+      iso: "2022-10-30",
+      kind: "slash-day-first",
+    });
+  });
+
+  it("parses unambiguous month-first slash dates", () => {
+    expect(parseOccurrenceEventDate("03/15/2024")).toEqual({
+      raw: "03/15/2024",
+      display: "15/03/2024",
+      iso: "2024-03-15",
+      kind: "slash-month-first",
+    });
+  });
+
+  it("keeps ambiguous slash dates display-only instead of guessing", () => {
+    expect(parseOccurrenceEventDate("03/04/2024 10:30")).toEqual({
+      raw: "03/04/2024 10:30",
+      display: "03/04/2024",
+      kind: "slash-ambiguous",
+    });
+  });
+
+  it("parses plausible Excel serial dates", () => {
+    expect(parseOccurrenceEventDate("44846.60625")).toEqual({
+      raw: "44846.60625",
+      display: "12/10/2022",
+      iso: "2022-10-12",
+      kind: "excel-serial",
+    });
+  });
+
+  it("returns null for invalid values", () => {
+    expect(parseOccurrenceEventDate("not-a-date")).toBeNull();
+  });
+});
+
+describe("normalizeOccurrenceEventDate", () => {
+  it("returns canonical ISO dates for supported formats", () => {
+    expect(normalizeOccurrenceEventDate("30/10/22 12:09")).toBe("2022-10-30");
+    expect(normalizeOccurrenceEventDate("2024")).toBe("2024");
+  });
+
+  it("returns null for ambiguous slash dates", () => {
+    expect(normalizeOccurrenceEventDate("03/04/2024")).toBeNull();
+  });
+});
+
+describe("formatOccurrenceEventDate", () => {
+  it("formats supported dates for UI display", () => {
+    expect(formatOccurrenceEventDate("30/10/22 12:09")).toBe("30/10/2022");
+  });
+
+  it("falls back to unknown for invalid values", () => {
+    expect(formatOccurrenceEventDate("not-a-date")).toBe("unknown");
+  });
+});

--- a/src/lib/occurrence-event-date.ts
+++ b/src/lib/occurrence-event-date.ts
@@ -1,0 +1,228 @@
+const YEAR_ONLY_PATTERN = /^\d{4}$/;
+const ISO_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const ISO_DATE_TIME_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})(?:[T ])(\d{2}):(\d{2})(?::(\d{2})(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})?$/;
+const SLASH_DATE_PATTERN =
+  /^(\d{1,2})\/(\d{1,2})\/(\d{2}|\d{4})(?:\s+(\d{1,2}):(\d{2})(?::(\d{2}))?)?$/;
+
+const EXCEL_EPOCH_OFFSET_DAYS = 25569;
+const MILLISECONDS_PER_DAY = 86_400_000;
+const MIN_EXCEL_SERIAL = 20_000;
+const MAX_EXCEL_SERIAL = 80_000;
+
+type SlashDateOrder = "day-first" | "month-first" | "ambiguous";
+
+export type ParsedOccurrenceEventDate = {
+  raw: string;
+  display: string;
+  iso?: string;
+  kind:
+    | "year"
+    | "iso-date"
+    | "iso-datetime"
+    | "slash-day-first"
+    | "slash-month-first"
+    | "slash-ambiguous"
+    | "excel-serial";
+};
+
+const pad2 = (value: number) => String(value).padStart(2, "0");
+
+const toIsoDate = (year: number, month: number, day: number) =>
+  `${year}-${pad2(month)}-${pad2(day)}`;
+
+const toDisplayDate = (year: number, month: number, day: number) =>
+  `${pad2(day)}/${pad2(month)}/${year}`;
+
+const isValidDate = (year: number, month: number, day: number): boolean => {
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+};
+
+const isValidTime = (
+  hour: number,
+  minute: number,
+  second: number,
+): boolean => {
+  return (
+    Number.isInteger(hour) &&
+    Number.isInteger(minute) &&
+    Number.isInteger(second) &&
+    hour >= 0 &&
+    hour <= 23 &&
+    minute >= 0 &&
+    minute <= 59 &&
+    second >= 0 &&
+    second <= 59
+  );
+};
+
+const expandTwoDigitYear = (year: number) =>
+  year < 100 ? 2000 + year : year;
+
+const inferSlashDateOrder = (
+  first: number,
+  second: number,
+): SlashDateOrder | null => {
+  if (first < 1 || second < 1 || first > 31 || second > 31) {
+    return null;
+  }
+
+  if (first > 12 && second <= 12) {
+    return "day-first";
+  }
+
+  if (second > 12 && first <= 12) {
+    return "month-first";
+  }
+
+  if (first <= 12 && second <= 12) {
+    return "ambiguous";
+  }
+
+  return null;
+};
+
+const parseExcelSerialDate = (raw: string): ParsedOccurrenceEventDate | null => {
+  if (!/^\d+(?:\.\d+)?$/.test(raw)) {
+    return null;
+  }
+
+  const serial = Number(raw);
+  if (
+    !Number.isFinite(serial) ||
+    serial < MIN_EXCEL_SERIAL ||
+    serial > MAX_EXCEL_SERIAL
+  ) {
+    return null;
+  }
+
+  const utcDate = new Date(
+    Math.round((serial - EXCEL_EPOCH_OFFSET_DAYS) * MILLISECONDS_PER_DAY),
+  );
+  const year = utcDate.getUTCFullYear();
+  const month = utcDate.getUTCMonth() + 1;
+  const day = utcDate.getUTCDate();
+
+  if (!isValidDate(year, month, day)) {
+    return null;
+  }
+
+  return {
+    raw,
+    display: toDisplayDate(year, month, day),
+    iso: toIsoDate(year, month, day),
+    kind: "excel-serial",
+  };
+};
+
+export const parseOccurrenceEventDate = (
+  rawValue: string | null | undefined,
+): ParsedOccurrenceEventDate | null => {
+  if (typeof rawValue !== "string") {
+    return null;
+  }
+
+  const raw = rawValue.trim();
+  if (!raw) {
+    return null;
+  }
+
+  if (YEAR_ONLY_PATTERN.test(raw)) {
+    return {
+      raw,
+      display: raw,
+      iso: raw,
+      kind: "year",
+    };
+  }
+
+  const isoDateMatch = raw.match(ISO_DATE_PATTERN);
+  if (isoDateMatch) {
+    const year = Number(isoDateMatch[1]);
+    const month = Number(isoDateMatch[2]);
+    const day = Number(isoDateMatch[3]);
+
+    if (!isValidDate(year, month, day)) {
+      return null;
+    }
+
+    return {
+      raw,
+      display: toDisplayDate(year, month, day),
+      iso: toIsoDate(year, month, day),
+      kind: "iso-date",
+    };
+  }
+
+  const isoDateTimeMatch = raw.match(ISO_DATE_TIME_PATTERN);
+  if (isoDateTimeMatch) {
+    const year = Number(isoDateTimeMatch[1]);
+    const month = Number(isoDateTimeMatch[2]);
+    const day = Number(isoDateTimeMatch[3]);
+    const hour = Number(isoDateTimeMatch[4]);
+    const minute = Number(isoDateTimeMatch[5]);
+    const second = isoDateTimeMatch[6] ? Number(isoDateTimeMatch[6]) : 0;
+
+    if (!isValidDate(year, month, day) || !isValidTime(hour, minute, second)) {
+      return null;
+    }
+
+    return {
+      raw,
+      display: toDisplayDate(year, month, day),
+      iso: toIsoDate(year, month, day),
+      kind: "iso-datetime",
+    };
+  }
+
+  const slashMatch = raw.match(SLASH_DATE_PATTERN);
+  if (slashMatch) {
+    const first = Number(slashMatch[1]);
+    const second = Number(slashMatch[2]);
+    const rawYear = Number(slashMatch[3]);
+    const year = expandTwoDigitYear(rawYear);
+    const order = inferSlashDateOrder(first, second);
+
+    if (order === null) {
+      return null;
+    }
+
+    if (order === "ambiguous") {
+      return {
+        raw,
+        display: `${pad2(first)}/${pad2(second)}/${year}`,
+        kind: "slash-ambiguous",
+      };
+    }
+
+    const day = order === "day-first" ? first : second;
+    const month = order === "day-first" ? second : first;
+
+    if (!isValidDate(year, month, day)) {
+      return null;
+    }
+
+    return {
+      raw,
+      display: toDisplayDate(year, month, day),
+      iso: toIsoDate(year, month, day),
+      kind: order === "day-first" ? "slash-day-first" : "slash-month-first",
+    };
+  }
+
+  return parseExcelSerialDate(raw);
+};
+
+export const formatOccurrenceEventDate = (
+  rawValue: string | null | undefined,
+): string => parseOccurrenceEventDate(rawValue)?.display ?? "unknown";
+
+export const normalizeOccurrenceEventDate = (
+  rawValue: string | null | undefined,
+): string | null => parseOccurrenceEventDate(rawValue)?.iso ?? null;

--- a/src/lib/upload/pds-writer.ts
+++ b/src/lib/upload/pds-writer.ts
@@ -6,6 +6,7 @@ import type {
   MeasurementInput,
   OccurrenceInput,
 } from "@/lib/upload/types";
+import { normalizeOccurrenceEventDate } from "@/lib/occurrence-event-date";
 
 const DWC_OCCURRENCE_COLLECTION = "app.gainforest.dwc.occurrence";
 const DWC_MEASUREMENT_COLLECTION = "app.gainforest.dwc.measurement";
@@ -26,11 +27,18 @@ export async function writeOccurrenceToPds(
   projectRef?: string
 ): Promise<{ uri: string; rkey: string }> {
   const rkey = TID.nextStr();
+  const normalizedEventDate = normalizeOccurrenceEventDate(occurrence.eventDate);
+
+  if (!normalizedEventDate) {
+    throw new Error(
+      "Occurrence eventDate must be a valid, unambiguous date before writing to the PDS",
+    );
+  }
 
   const record: Record<string, unknown> = {
     basisOfRecord: occurrence.basisOfRecord ?? "HumanObservation",
     scientificName: occurrence.scientificName,
-    eventDate: occurrence.eventDate,
+    eventDate: normalizedEventDate,
     decimalLatitude: String(occurrence.decimalLatitude),
     decimalLongitude: String(occurrence.decimalLongitude),
     geodeticDatum: "EPSG:4326",

--- a/src/lib/upload/schemas.test.ts
+++ b/src/lib/upload/schemas.test.ts
@@ -60,8 +60,15 @@ describe("OccurrenceRowSchema", () => {
   });
 
   it("accepts various valid date formats", () => {
-    const dates = ["2024-03-15", "03/15/2024", "2024", "2024-03-15T10:30:00Z"];
-    for (const eventDate of dates) {
+    const dates = [
+      ["2024-03-15", "2024-03-15"],
+      ["03/15/2024", "2024-03-15"],
+      ["30/10/22 12:09", "2022-10-30"],
+      ["44846.60625", "2022-10-12"],
+      ["2024", "2024"],
+      ["2024-03-15T10:30:00Z", "2024-03-15"],
+    ] as const;
+    for (const [eventDate, normalized] of dates) {
       const result = OccurrenceRowSchema.safeParse({
         scientificName: "Quercus robur",
         eventDate,
@@ -69,6 +76,23 @@ describe("OccurrenceRowSchema", () => {
         decimalLongitude: "-0.1",
       });
       expect(result.success, `Expected date "${eventDate}" to be valid`).toBe(true);
+      if (result.success) {
+        expect(result.data.eventDate).toBe(normalized);
+      }
+    }
+  });
+
+  it("rejects ambiguous slash date formats", () => {
+    const result = OccurrenceRowSchema.safeParse({
+      scientificName: "Quercus robur",
+      eventDate: "03/04/2024",
+      decimalLatitude: "51.5",
+      decimalLongitude: "-0.1",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path[0]);
+      expect(paths).toContain("eventDate");
     }
   });
 

--- a/src/lib/upload/schemas.ts
+++ b/src/lib/upload/schemas.ts
@@ -1,27 +1,28 @@
 import { z } from "zod";
+import { normalizeOccurrenceEventDate } from "@/lib/occurrence-event-date";
 import type { FloraMeasurementBundle, OccurrenceInput, ValidationResult } from "./types";
 
-const DATE_PATTERNS = [
-  /^\d{4}-\d{2}-\d{2}$/, // YYYY-MM-DD
-  /^\d{2}\/\d{2}\/\d{4}$/, // MM/DD/YYYY
-  /^\d{2}\/\d{2}\/\d{4}$/, // DD/MM/YYYY (same regex, both accepted)
-  /^\d{4}$/, // YYYY
-  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, // ISO 8601 datetime
-];
+const EventDateSchema = z
+  .string()
+  .min(1, "Event date is required")
+  .transform((value, ctx) => {
+    const normalized = normalizeOccurrenceEventDate(value);
 
-function isValidDate(value: string): boolean {
-  return DATE_PATTERNS.some((pattern) => pattern.test(value));
-}
+    if (!normalized) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "Event date must be ISO 8601 or an unambiguous common date format",
+      });
+      return z.NEVER;
+    }
+
+    return normalized;
+  });
 
 export const OccurrenceRowSchema = z.object({
   scientificName: z.string().min(1, "Scientific name is required"),
-  eventDate: z
-    .string()
-    .min(1, "Event date is required")
-    .refine(isValidDate, {
-      message:
-        "Date must be in ISO 8601 or common format (YYYY-MM-DD, MM/DD/YYYY, DD/MM/YYYY, YYYY)",
-    }),
+  eventDate: EventDateSchema,
   decimalLatitude: z.coerce.number().min(-90).max(90),
   decimalLongitude: z.coerce.number().min(-180).max(180),
   basisOfRecord: z.string().optional().default("HumanObservation"),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a shared measured-tree event date normalizer that handles ISO dates, legacy day-first slash dates, and plausible Excel serial values without showing `Invalid Date`
- normalize measured-tree dates on the read path, hover overlay, exports, and upload/PDS write flow so canonical ISO values are used when safe
- add regression tests for Oceanus-style legacy dates and ambiguous slash-date rejection

## Validation
- `bunx vitest run src/lib/occurrence-event-date.test.ts src/lib/upload/schemas.test.ts`
- `bun run lint`
- `bunx tsc --noEmit`
- `bun run build`