### PR TITLE
fix(project): derive overlay area from active site geometry

### DIFF
--- a/src/app/(map-routes)/(main)/_components/ProjectOverlay/Header.tsx
+++ b/src/app/(map-routes)/(main)/_components/ProjectOverlay/Header.tsx
@@ -110,6 +110,17 @@ const Tabs = () => {
   );
 };
 
+const formatAreaHectares = (areaHectares: number | null) => {
+  if (areaHectares === null || !Number.isFinite(areaHectares) || areaHectares <= 0) {
+    return null;
+  }
+
+  return areaHectares.toLocaleString(undefined, {
+    minimumFractionDigits: areaHectares < 1 ? 1 : 0,
+    maximumFractionDigits: areaHectares < 10 ? 2 : 0,
+  });
+};
+
 const Header = ({
   organization,
 }: {
@@ -119,8 +130,10 @@ const Header = ({
     Object.keys(countryToEmoji).includes(organization.country) ?
       countryToEmoji[organization.country as keyof typeof countryToEmoji]
     : null;
-  // @satyam TODO: Fix the area thing.
-  const area = Math.round(0 / 10000);
+  const activeSiteAreaHectares = useProjectOverlayStore(
+    (state) => state.activeSiteAreaHectares
+  );
+  const formattedArea = formatAreaHectares(activeSiteAreaHectares);
 
   const activeTab = useProjectOverlayStore((state) => state.activeTab);
   const headerRef = useRef<HTMLDivElement>(null);
@@ -163,16 +176,21 @@ const Header = ({
       >
         {organization.displayName}
       </h1>
-      {countryDetails && (
+      {(countryDetails || formattedArea) && (
         <div className="flex items-center gap-2 flex-wrap mt-2">
-          <span className="px-2 py-1 bg-background/50 backdrop-blur-lg rounded-full text-sm">
-            {countryDetails.emoji}
-            &nbsp;&nbsp;
-            {countryDetails.name}
-          </span>
-          {Boolean(area) && (
+          {countryDetails && (
             <span className="px-2 py-1 bg-background/50 backdrop-blur-lg rounded-full text-sm">
-              <b>{area}</b> {area === 1 ? "hectare" : "hectares"}
+              {countryDetails.emoji}
+              &nbsp;&nbsp;
+              {countryDetails.name}
+            </span>
+          )}
+          {formattedArea && (
+            <span
+              data-testid="project-area"
+              className="px-2 py-1 bg-background/50 backdrop-blur-lg rounded-full text-sm"
+            >
+              <b>{formattedArea}</b> {formattedArea === "1" ? "hectare" : "hectares"}
             </span>
           )}
         </div>

--- a/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/index.ts
+++ b/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/index.ts
@@ -15,6 +15,7 @@ import {
 import useNavigation from "@/app/(map-routes)/(main)/_features/navigation/use-navigation";
 import { Agent } from "@atproto/api";
 import { resolvePdsEndpoint } from "@/lib/atproto/resolve-pds";
+import { computePolygonMetrics } from "@/lib/geojson";
 import { fetchMeasuredTreeOccurrences } from "../../../_hooks/use-organization-measured-trees";
 import { hyperindexClient } from "@/lib/hyperindex/client";
 import {
@@ -247,6 +248,7 @@ type ProjectStateCatalog = {
     allSitesOptions: null;
     siteId: null;
     activeSite: null;
+    activeSiteAreaHectares: null;
     treesAsync: null;
     projectSlug: null;
     atprotoSites: null;
@@ -257,6 +259,7 @@ type ProjectStateCatalog = {
     allSitesOptions: ProjectSiteOption[];
     siteId: string | null;
     activeSite: AtprotoSite | null;
+    activeSiteAreaHectares: number | null;
     treesAsync: AsyncData<MeasuredTreesGeoJSON | null>;
     projectSlug: string;
     atprotoSites: AtprotoSite[];
@@ -267,6 +270,7 @@ type ProjectStateCatalog = {
     allSitesOptions: null;
     siteId: null;
     activeSite: null;
+    activeSiteAreaHectares: null;
     treesAsync: null;
     projectSlug: null;
     atprotoSites: null;
@@ -322,6 +326,7 @@ const initialProjectState: ProjectState = {
   allSitesOptions: null,
   siteId: null,
   activeSite: null,
+  activeSiteAreaHectares: null,
   projectSlug: null,
   atprotoSites: null,
 };
@@ -337,6 +342,10 @@ const useProjectOverlayStore = create<
   ProjectOverlayState & ProjectOverlayActions
 >((set, get) => {
   const isProjectStillActive = (id: string) => get().projectId === id;
+  const isSiteStillActive = (projectId: string, siteId: string | null) => {
+    const state = get();
+    return state.projectId === projectId && state.siteId === siteId;
+  };
 
   const loadProjectTrees = async (
     projectId: string,
@@ -529,12 +538,26 @@ const useProjectOverlayStore = create<
 
       set({
         activeSite: selectedSite ?? null,
+        activeSiteAreaHectares: null,
         treesAsync: { _status: "loading", data: null },
       });
 
       if (selectedSite) {
+        const selectedSiteId = selectedSite.uri;
+
         fetchSiteShapefile(projectId, selectedSite.shapefile).then((data) => {
-          if (data === null) return;
+          if (!isSiteStillActive(projectId, selectedSiteId)) {
+            return;
+          }
+
+          if (data === null) {
+            set({ activeSiteAreaHectares: null });
+            return;
+          }
+
+          const { areaHectares } = computePolygonMetrics(data);
+          set({ activeSiteAreaHectares: areaHectares });
+
           const boundingBox = bbox(data as unknown as GeoJSON.FeatureCollection).slice(0, 4) as [
             number,
             number,


### PR DESCRIPTION
## Summary
- derive the project overlay area badge from the active certified location geometry already loaded for the selected site
- store active site hectares in overlay state and ignore stale boundary fetches when users switch sites quickly
- render the area badge independently of country metadata so valid site areas still appear

## Testing
- bun run lint -- --file \"src/app/(map-routes)/(main)/_components/ProjectOverlay/Header.tsx\" --file \"src/app/(map-routes)/(main)/_components/ProjectOverlay/store/index.ts\"
- bunx tsc --noEmit