### PR TITLE
fix(navigation): keep project tab active when opening projects

### DIFF
--- a/src/app/(map-routes)/(main)/_components/Map/hooks/useMapbox.ts
+++ b/src/app/(map-routes)/(main)/_components/Map/hooks/useMapbox.ts
@@ -6,7 +6,6 @@ import {
   spinGlobe,
 } from "@/app/(map-routes)/_utils/map";
 import useProjectOverlayStore from "../../ProjectOverlay/store";
-import useOverlayTabsStore from "@/app/(map-routes)/(main)/_components/Overlay/OverlayTabs/store";
 import mapboxgl, { GeoJSONSource, Map as MapInterface } from "mapbox-gl";
 import { MAP_CONFIG, MAP_FOG_CONFIG } from "../../../../../../config/map";
 import useNavigation from "@/app/(map-routes)/(main)/_features/navigation/use-navigation";
@@ -22,7 +21,6 @@ const useMapbox = (mapContainerRef: React.RefObject<HTMLDivElement | null>) => {
   const setMapLoaded = useMapStore((state) => state.setMapLoaded);
 
   const setCurrentView = useMapStore((state) => state.setCurrentView);
-  const setOverlayTab = useOverlayTabsStore((actions) => actions.setActiveTab);
   const setActiveProjectId = useProjectOverlayStore(
     (actions) => actions.setProjectId
   );
@@ -31,10 +29,7 @@ const useMapbox = (mapContainerRef: React.RefObject<HTMLDivElement | null>) => {
 
   const handleOrganizationPointClick = (organizationId: string) => {
     setCurrentView("project");
-    setOverlayTab("project", navigate);
-    setTimeout(() => {
-      setActiveProjectId(organizationId, navigate);
-    }, 400);
+    setActiveProjectId(organizationId, navigate);
   };
 
   useEffect(() => {

--- a/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/index.ts
+++ b/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/index.ts
@@ -5,6 +5,7 @@ import {
   fetchSiteShapefile,
 } from "./utils";
 import useMapStore from "../../Map/store";
+import useOverlayTabsStore from "../../Overlay/OverlayTabs/store";
 import bbox from "@turf/bbox";
 import { MeasuredTreesGeoJSON } from "./types";
 import { AsyncData } from "@/lib/types";
@@ -432,12 +433,16 @@ const useProjectOverlayStore = create<
         projectId,
         ...initialProjectState,
       });
-      navigate?.({
-        project: {
+      if (navigate) {
+        useOverlayTabsStore.getState().setActiveTab("project");
+      }
+      navigate?.((draft) => {
+        draft.overlay["active-tab"] = "project";
+        draft.project = {
           "project-id": projectId,
           "site-id": null,
           views: ["info"],
-        },
+        };
       });
 
       // Fetch ATProto data in parallel: sites + default site + handle/slug

--- a/src/app/(map-routes)/(main)/_components/SearchOverlay/index.tsx
+++ b/src/app/(map-routes)/(main)/_components/SearchOverlay/index.tsx
@@ -56,9 +56,6 @@ const SearchOverlay = () => {
 
   const handleOrganizationClick = (organizationId: string) => {
     setProjectId(organizationId, navigate);
-    setTimeout(() => {
-      setActiveTab("project", navigate);
-    }, 400);
     setCurrentMapView("project");
   };
 

--- a/src/app/(map-routes)/(main)/_features/navigation/use-navigation.ts
+++ b/src/app/(map-routes)/(main)/_features/navigation/use-navigation.ts
@@ -13,9 +13,15 @@ const useNavigation = () => {
   const navigate = (
     state: Partial<NavigationState> | ((draft: NavigationState) => void)
   ) => {
-    const currentState = useNavigationStore.getState();
+    const { overlay, layers, search, project, map } = useNavigationStore.getState();
+    const currentState: NavigationState = {
+      overlay,
+      layers,
+      search,
+      project,
+      map,
+    };
 
-    // Create new state using Immer without updating the store
     const newState =
       typeof state === "function" ?
         produce(currentState, state)
@@ -23,13 +29,21 @@ const useNavigation = () => {
           Object.assign(draft, state);
         });
 
-    const { overlay, layers, search, project, map } = newState;
+    useNavigationStore.getState().updateNavigationState(newState);
 
-    const overlayQueryString = generateQueryStringFromOverlay(overlay);
-    const layersQueryString = generateQueryStringFromLayers(layers);
-    const searchQueryString = generateQueryStringFromSearch(search);
-    const projectQueryString = generateQueryStringFromProject(project);
-    const mapQueryString = generateQueryStringFromMap(map);
+    const {
+      overlay: nextOverlay,
+      layers: nextLayers,
+      search: nextSearch,
+      project: nextProject,
+      map: nextMap,
+    } = newState;
+
+    const overlayQueryString = generateQueryStringFromOverlay(nextOverlay);
+    const layersQueryString = generateQueryStringFromLayers(nextLayers);
+    const searchQueryString = generateQueryStringFromSearch(nextSearch);
+    const projectQueryString = generateQueryStringFromProject(nextProject);
+    const mapQueryString = generateQueryStringFromMap(nextMap);
 
     const queryString = [
       overlayQueryString,
@@ -41,10 +55,10 @@ const useNavigation = () => {
       .filter((str) => str.trim() !== "")
       .join("&");
 
-    if (project === null) {
+    if (nextProject === null) {
       router.push(`/?${queryString}`);
     } else {
-      router.push(`/${project["project-id"]}?${queryString}`);
+      router.push(`/${nextProject["project-id"]}?${queryString}`);
     }
   };
 


### PR DESCRIPTION
## Summary
- persist the computed navigation state before route pushes so follow-up updates do not reuse stale overlay values
- open projects in a single transition that sets both the project route and the overlay tab to Project
- remove delayed tab switching from search results and globe marker clicks so both entry points share the same path

## Testing
- bun run lint
- bun run build