### PR TITLE
Focus selected dataset trees in embeds

### DIFF
--- a/src/app/(map-routes)/(main)/_components/HoveredTreeOverlay/index.tsx
+++ b/src/app/(map-routes)/(main)/_components/HoveredTreeOverlay/index.tsx
@@ -14,6 +14,8 @@ import useHoveredTreeOverlayStore from "./store";
 import useOverlayStore from "../Overlay/store";
 import { cn } from "@/lib/utils";
 import useBlurAnimate from "../../_hooks/useBlurAnimate";
+import usePreviewStore from "../../_features/preview/store";
+
 const HoveredTreeOverlay = () => {
   const { animate, onAnimationComplete } = useBlurAnimate(
     { opacity: 1, scale: 1, filter: "blur(0px)" },
@@ -27,6 +29,7 @@ const HoveredTreeOverlay = () => {
   const setIsExpanded = useHoveredTreeOverlayStore(
     (state) => state.setIsExpanded
   );
+  const isEmbedMode = usePreviewStore((state) => state.embedMode);
 
   if (!hoveredTree) return null;
 
@@ -40,19 +43,39 @@ const HoveredTreeOverlay = () => {
           exit={{ opacity: 0, scale: 0.95, filter: "blur(10px)" }}
           onAnimationComplete={onAnimationComplete}
           className={cn(
-            "fixed right-2 w-[25%] max-w-[280px] min-w-[180px]",
-            overlaySize === "desktop" ? "top-2" : "top-16"
+            isEmbedMode
+              ? "fixed right-2 max-h-[calc(100dvh-1rem)] w-[min(20rem,calc(100vw-1rem))] max-w-[calc(100vw-1rem)]"
+              : "fixed right-2 w-[25%] max-w-[280px] min-w-[180px]",
+            isEmbedMode || overlaySize === "desktop" ? "top-2" : "top-16"
           )}
         >
-          <UIBase innerClassName="p-0 overflow-hidden relative">
+          <UIBase
+            className={cn(
+              isEmbedMode && "max-h-[calc(100dvh-1rem)] overflow-hidden"
+            )}
+            innerClassName={cn(
+              "p-0 relative",
+              isEmbedMode
+                ? "max-h-[calc(100dvh-1rem)] overflow-y-auto overscroll-contain"
+                : "overflow-hidden"
+            )}
+          >
             <Image
               src={hoveredTree.treePhotos[0]}
               width={400}
               height={400}
               alt="Hovered Tree"
-              className="w-full h-auto object-cover object-center [mask-image:linear-gradient(to_bottom,black_40%,transparent_100%)]"
+              className={cn(
+                "w-full object-cover object-center [mask-image:linear-gradient(to_bottom,black_40%,transparent_100%)]",
+                isEmbedMode ? "h-32" : "h-auto"
+              )}
             />
-            <div className="px-4 pb-2 flex flex-col gap-2 -mt-12">
+            <div
+              className={cn(
+                "px-4 pb-2 flex flex-col gap-2",
+                isEmbedMode ? "-mt-8" : "-mt-12"
+              )}
+            >
               <div className="flex flex-col gap-1 items-start">
                 <span className="bg-muted/70 backdrop-blur-lg text-muted-foreground text-sm px-3 py-1 rounded-full flex items-center gap-2">
                   <Leaf size={16} />
@@ -122,7 +145,7 @@ const HoveredTreeOverlay = () => {
           onAnimationComplete={onAnimationComplete}
           className={cn(
             "fixed right-2 flex flex-col items-end gap-2",
-            overlaySize === "desktop" ? "top-2" : "top-16"
+            isEmbedMode || overlaySize === "desktop" ? "top-2" : "top-16"
           )}
         >
           <UIBase innerClassName="w-28 p-0 overflow-hidden">

--- a/src/app/(map-routes)/(main)/_components/Map/hooks/useSelectedTreeHighlight.ts
+++ b/src/app/(map-routes)/(main)/_components/Map/hooks/useSelectedTreeHighlight.ts
@@ -1,9 +1,15 @@
 import { useEffect, useRef } from "react";
+import { GeoJSONSource } from "mapbox-gl";
 import useMapStore from "../store";
 import useProjectOverlayStore from "../../ProjectOverlay/store";
 import usePreviewStore from "../../../_features/preview/store";
 
 type FeatureIdentifier = string | number;
+
+const EMPTY_SELECTED_TREE_GEOJSON: GeoJSON.FeatureCollection = {
+  type: "FeatureCollection",
+  features: [],
+};
 
 const useSelectedTreeHighlight = () => {
   const currentView = useMapStore((state) => state.currentView);
@@ -14,6 +20,7 @@ const useSelectedTreeHighlight = () => {
   const selectedTreeUri = usePreviewStore((state) => state.treeUri);
 
   const selectedFeatureIdRef = useRef<FeatureIdentifier | null>(null);
+  const focusedTreeUriRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (currentView !== "project" || !activeProjectId) {
@@ -25,6 +32,14 @@ const useSelectedTreeHighlight = () => {
       return;
     }
 
+    const selectedTreeSource = map.getSource("selectedTreeSource") as
+      | GeoJSONSource
+      | undefined;
+
+    const clearSelectedTreeSource = () => {
+      selectedTreeSource?.setData(EMPTY_SELECTED_TREE_GEOJSON);
+    };
+
     const previousFeatureId = selectedFeatureIdRef.current;
     if (previousFeatureId !== null) {
       map.setFeatureState(
@@ -35,6 +50,8 @@ const useSelectedTreeHighlight = () => {
     }
 
     if (treesAsync?._status !== "success" || !selectedTreeUri) {
+      clearSelectedTreeSource();
+      focusedTreeUriRef.current = null;
       return;
     }
 
@@ -43,8 +60,14 @@ const useSelectedTreeHighlight = () => {
     );
 
     if (!matchingFeature) {
+      clearSelectedTreeSource();
       return;
     }
+
+    selectedTreeSource?.setData({
+      type: "FeatureCollection",
+      features: [matchingFeature],
+    });
 
     map.setFeatureState(
       { source: "trees", id: matchingFeature.id },
@@ -52,14 +75,35 @@ const useSelectedTreeHighlight = () => {
     );
     selectedFeatureIdRef.current = matchingFeature.id;
 
+    if (focusedTreeUriRef.current !== selectedTreeUri) {
+      const [lon, lat] = matchingFeature.geometry.coordinates;
+      map.easeTo({
+        center: [lon, lat],
+        duration: 550,
+        essential: true,
+      });
+      focusedTreeUriRef.current = selectedTreeUri;
+    }
+
     return () => {
       const featureId = selectedFeatureIdRef.current;
       if (featureId !== null && map.getSource("trees")) {
-        map.setFeatureState({ source: "trees", id: featureId }, { selected: false });
+        map.setFeatureState(
+          { source: "trees", id: featureId },
+          { selected: false },
+        );
       }
+      clearSelectedTreeSource();
       selectedFeatureIdRef.current = null;
     };
-  }, [activeProjectId, currentView, mapLoaded, mapRef, selectedTreeUri, treesAsync]);
+  }, [
+    activeProjectId,
+    currentView,
+    mapLoaded,
+    mapRef,
+    selectedTreeUri,
+    treesAsync,
+  ]);
 };
 
 export default useSelectedTreeHighlight;

--- a/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/measured-trees.ts
+++ b/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/measured-trees.ts
@@ -28,6 +28,14 @@ export const treesSource: GeoJSONSourceSpecification = {
   clusterRadius: 50, // Radius of each cluster when clustering points (defaults to 50)
 };
 
+export const selectedTreeSource: GeoJSONSourceSpecification = {
+  type: "geojson",
+  data: {
+    type: "FeatureCollection",
+    features: [],
+  },
+};
+
 export const clusteredTreesLayer: CircleLayerSpecification = {
   id: "clusteredTrees",
   type: "circle" as const,
@@ -91,9 +99,38 @@ export const unclusteredTreesLayer: CircleLayerSpecification = {
   },
 };
 
+export const selectedTreeHaloLayer: CircleLayerSpecification = {
+  id: "selectedTreeHalo",
+  type: "circle",
+  source: "selectedTreeSource",
+  paint: {
+    "circle-color": "#facc15",
+    "circle-opacity": 0.35,
+    "circle-radius": 18,
+    "circle-stroke-color": "#ffffff",
+    "circle-stroke-width": 2,
+    "circle-stroke-opacity": 0.95,
+  },
+};
+
+export const selectedTreePointLayer: CircleLayerSpecification = {
+  id: "selectedTreePoint",
+  type: "circle",
+  source: "selectedTreeSource",
+  paint: {
+    "circle-color": "#ec4899",
+    "circle-radius": 8,
+    "circle-stroke-color": "#ffffff",
+    "circle-stroke-width": 3,
+  },
+};
+
 export const addMeasuredTreesSourceAndLayer = (map: Map) => {
   if (!map.getSource("trees")) {
     map.addSource("trees", treesSource);
+  }
+  if (!map.getSource("selectedTreeSource")) {
+    map.addSource("selectedTreeSource", selectedTreeSource);
   }
   if (!map.getLayer("clusteredTrees")) {
     map.addLayer(clusteredTreesLayer);
@@ -103,6 +140,12 @@ export const addMeasuredTreesSourceAndLayer = (map: Map) => {
   }
   if (!map.getLayer("unclusteredTrees")) {
     map.addLayer(unclusteredTreesLayer);
+  }
+  if (!map.getLayer("selectedTreeHalo")) {
+    map.addLayer(selectedTreeHaloLayer);
+  }
+  if (!map.getLayer("selectedTreePoint")) {
+    map.addLayer(selectedTreePointLayer);
   }
 };
 

--- a/src/app/(map-routes)/(main)/_features/navigation/use-store-url-sync.ts
+++ b/src/app/(map-routes)/(main)/_features/navigation/use-store-url-sync.ts
@@ -10,6 +10,39 @@ import { updateDedicatedStoresFromViews } from "../../_features/navigation/utils
 import useMapStore from "../../_components/Map/store";
 import usePreviewStore from "../preview/store";
 
+const GREEN_GLOBE_PREVIEW_FOCUS_MESSAGE_TYPE =
+  "gainforest.greenGlobePreview.focusTree";
+
+type GreenGlobePreviewFocusMessage = {
+  type: typeof GREEN_GLOBE_PREVIEW_FOCUS_MESSAGE_TYPE;
+  datasetRef?: unknown;
+  treeUri?: unknown;
+};
+
+const isPreviewFocusMessage = (
+  value: unknown,
+): value is GreenGlobePreviewFocusMessage => {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    value.type === GREEN_GLOBE_PREVIEW_FOCUS_MESSAGE_TYPE
+  );
+};
+
+const normalizeNullableString = (value: unknown): string | null | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
 const useStoreUrlSync = (
   queryParams: ReadonlyURLSearchParams,
   params: {
@@ -100,6 +133,53 @@ const useStoreUrlSync = (
     }
 
   }, [embed, projectIdParam, queryParams]);
+
+  useEffect(() => {
+    if (!embed) {
+      return;
+    }
+
+    const handlePreviewFocusMessage = (event: MessageEvent) => {
+      if (!isPreviewFocusMessage(event.data)) {
+        return;
+      }
+
+      const previousPreviewState = usePreviewStore.getState();
+      const nextDatasetRef = normalizeNullableString(event.data.datasetRef);
+      const nextTreeUri = normalizeNullableString(event.data.treeUri);
+      const nextPreviewState = {
+        embedMode: true,
+        datasetRef:
+          nextDatasetRef === undefined
+            ? previousPreviewState.datasetRef
+            : nextDatasetRef,
+        treeUri:
+          nextTreeUri === undefined ? previousPreviewState.treeUri : nextTreeUri,
+      };
+
+      const datasetChanged =
+        previousPreviewState.datasetRef !== nextPreviewState.datasetRef;
+      const previewChanged =
+        previousPreviewState.embedMode !== nextPreviewState.embedMode ||
+        previousPreviewState.treeUri !== nextPreviewState.treeUri ||
+        datasetChanged;
+
+      if (!previewChanged) {
+        return;
+      }
+
+      usePreviewStore.getState().setPreviewState(nextPreviewState);
+
+      if (datasetChanged) {
+        useProjectOverlayStore.getState().refreshTrees();
+      }
+    };
+
+    window.addEventListener("message", handlePreviewFocusMessage);
+    return () => {
+      window.removeEventListener("message", handlePreviewFocusMessage);
+    };
+  }, [embed]);
 };
 
 export default useStoreUrlSync;


### PR DESCRIPTION
## Summary
- Add embed postMessage support for live dataset tree focus without iframe reloads.
- Render a dedicated non-clustered selected-tree layer so focused trees remain visible inside clusters.
- Constrain the hovered-tree panel in embed mode so expanded details fit inside the iframe.

## Tests
- bun run lint
- bun run build
- agent-browser verification of dataset focus, no URL reload, and expanded hover panel at iframe height