### PR TITLE
fix(layers): support full URLs in layer endpoints

### DIFF
--- a/src/app/(map-routes)/(main)/_components/LayersOverlay/index.tsx
+++ b/src/app/(map-routes)/(main)/_components/LayersOverlay/index.tsx
@@ -6,7 +6,7 @@ import { Label } from "@/components/ui/label";
 import useBlurAnimate from "../../_hooks/useBlurAnimate";
 import useLayersOverlayStore from "./store";
 import useProjectOverlayStore from "../ProjectOverlay/store";
-import { toKebabCase, resolveLayerUrl } from "@/lib/utils";
+import { toKebabCase, resolveLayerUrl, geojsonBbox } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import QuickTooltip from "@/components/ui/quick-tooltip";
 import useMapStore from "../Map/store";
@@ -70,20 +70,26 @@ const LayersOverlay = () => {
   }, [projectData?.id]);
 
   const handleZoomToProjectSpecificLayer = useCallback(
-    (layerEndpoint: string) => {
+    (layer: { endpoint: string; type: string }) => {
       setMapView("project");
-      fetch(
-        `${process.env.NEXT_PUBLIC_TITILER_ENDPOINT}/cog/bounds?url=${resolveLayerUrl(layerEndpoint)}`
-      )
-        .then((response) => {
-          return response.json();
-        })
-        .then((data) => {
-          if (!data) return;
-          if (!("bounds" in data)) return;
-          if (!Array.isArray(data.bounds)) return;
-          setMapBounds(data.bounds as [number, number, number, number]);
-        });
+      if (layer.type === "raster_tif") {
+        fetch(
+          `${process.env.NEXT_PUBLIC_TITILER_ENDPOINT}/cog/bounds?url=${resolveLayerUrl(layer.endpoint)}`
+        )
+          .then((r) => r.json())
+          .then((data) => {
+            if (!data || !("bounds" in data) || !Array.isArray(data.bounds))
+              return;
+            setMapBounds(data.bounds as [number, number, number, number]);
+          });
+      } else {
+        fetch(resolveLayerUrl(layer.endpoint))
+          .then((r) => r.json())
+          .then((data) => {
+            const bbox = geojsonBbox(data as Record<string, unknown>);
+            if (bbox) setMapBounds(bbox);
+          });
+      }
     },
     [setMapView, setMapBounds]
   );
@@ -164,7 +170,7 @@ const LayersOverlay = () => {
                           variant="outline"
                           size="icon"
                           onClick={() =>
-                            handleZoomToProjectSpecificLayer(layer.endpoint)
+                            handleZoomToProjectSpecificLayer(layer)
                           }
                         >
                           <LocateFixed size={16} />
@@ -178,7 +184,7 @@ const LayersOverlay = () => {
                         onCheckedChange={(value) => {
                         toggleLayer(layer.name, value);
                         if (value) {
-                          handleZoomToProjectSpecificLayer(layer.endpoint);
+                          handleZoomToProjectSpecificLayer(layer);
                         }
                       }}
                     />

--- a/src/app/(map-routes)/(main)/_components/LayersOverlay/index.tsx
+++ b/src/app/(map-routes)/(main)/_components/LayersOverlay/index.tsx
@@ -6,7 +6,7 @@ import { Label } from "@/components/ui/label";
 import useBlurAnimate from "../../_hooks/useBlurAnimate";
 import useLayersOverlayStore from "./store";
 import useProjectOverlayStore from "../ProjectOverlay/store";
-import { toKebabCase } from "@/lib/utils";
+import { toKebabCase, resolveLayerUrl } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import QuickTooltip from "@/components/ui/quick-tooltip";
 import useMapStore from "../Map/store";
@@ -73,7 +73,7 @@ const LayersOverlay = () => {
     (layerEndpoint: string) => {
       setMapView("project");
       fetch(
-        `${process.env.NEXT_PUBLIC_TITILER_ENDPOINT}/cog/bounds?url=${process.env.NEXT_PUBLIC_AWS_STORAGE}/${layerEndpoint}`
+        `${process.env.NEXT_PUBLIC_TITILER_ENDPOINT}/cog/bounds?url=${resolveLayerUrl(layerEndpoint)}`
       )
         .then((response) => {
           return response.json();

--- a/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/dynamic-layers/chloropleth.ts
+++ b/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/dynamic-layers/chloropleth.ts
@@ -1,11 +1,12 @@
 import { Map } from "mapbox-gl";
 import { DynamicLayer } from "@/app/(map-routes)/(main)/_components/LayersOverlay/store/types";
+import { resolveLayerUrl } from "@/lib/utils";
 
 const addChoroplethSourceAndLayers = (map: Map, layer: DynamicLayer) => {
   if (!map.getSource(layer.name)) {
     map.addSource(layer.name, {
       type: "geojson",
-      data: `${process.env.NEXT_PUBLIC_AWS_STORAGE}/${layer.endpoint}`,
+      data: resolveLayerUrl(layer.endpoint),
     });
   }
 

--- a/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/dynamic-layers/line.ts
+++ b/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/dynamic-layers/line.ts
@@ -1,5 +1,6 @@
 import { EMPTY_GEOJSON } from "@/constants";
 import { Map } from "mapbox-gl";
+import { resolveLayerUrl } from "@/lib/utils";
 
 const geojsonLineSource = (treeCrownGeojson = EMPTY_GEOJSON) => ({
   type: "geojson" as const,
@@ -26,9 +27,7 @@ const addGeojsonLineSourceAndLayer = async (
   layer: { name: string; endpoint: string; type: string }
 ) => {
   try {
-    const res = await fetch(
-      `${process.env.NEXT_PUBLIC_AWS_STORAGE}/${layer.endpoint}`
-    );
+    const res = await fetch(resolveLayerUrl(layer.endpoint));
     const treeCrownGeojson = await res.json();
 
     if (!map.getSource(layer.name)) {

--- a/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/dynamic-layers/points.ts
+++ b/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/dynamic-layers/points.ts
@@ -1,13 +1,12 @@
 import { DynamicLayer } from "@/app/(map-routes)/(main)/_components/LayersOverlay/store/types";
 import { EMPTY_GEOJSON } from "@/constants";
 import { Map } from "mapbox-gl";
+import { resolveLayerUrl } from "@/lib/utils";
 
 const addGeojsonPointSourceAndLayer = async (map: Map, layer: DynamicLayer) => {
   let pointsGeojson = EMPTY_GEOJSON;
   try {
-    const res = await fetch(
-      `${process.env.NEXT_PUBLIC_AWS_STORAGE}/${layer.endpoint}`
-    );
+    const res = await fetch(resolveLayerUrl(layer.endpoint));
     pointsGeojson = await res.json();
   } catch (error) {
     console.error("Error fetching points geojson", error);

--- a/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/dynamic-layers/raster.ts
+++ b/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/dynamic-layers/raster.ts
@@ -1,4 +1,5 @@
 import { Map } from "mapbox-gl";
+import { resolveLayerUrl } from "@/lib/utils";
 
 const addRasterSourceAndLayer = async (
   map: Map,
@@ -9,7 +10,7 @@ const addRasterSourceAndLayer = async (
       map.addSource(layer.name, {
         type: "raster",
         tiles: [
-          `${process.env.NEXT_PUBLIC_TITILER_ENDPOINT}/cog/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?url=${process.env.NEXT_PUBLIC_AWS_STORAGE}/${layer.endpoint}`,
+          `${process.env.NEXT_PUBLIC_TITILER_ENDPOINT}/cog/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?url=${resolveLayerUrl(layer.endpoint)}`,
         ],
       });
     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -60,3 +60,49 @@ export const resolveLayerUrl = (endpoint: string): string => {
   }
   return `${process.env.NEXT_PUBLIC_AWS_STORAGE}/${endpoint}`;
 };
+
+// Recursively collect all [lng, lat] pairs from any GeoJSON geometry coordinate array.
+function collectCoords(value: unknown, out: [number, number][]): void {
+  if (!Array.isArray(value)) return;
+  if (typeof value[0] === "number" && typeof value[1] === "number") {
+    out.push([value[0] as number, value[1] as number]);
+  } else {
+    for (const child of value) collectCoords(child, out);
+  }
+}
+
+export const geojsonBbox = (
+  geojson: Record<string, unknown>
+): [number, number, number, number] | null => {
+  const coords: [number, number][] = [];
+
+  const processGeometry = (geom: Record<string, unknown>) => {
+    if (!geom) return;
+    if (geom.type === "GeometryCollection") {
+      for (const g of (geom.geometries as Record<string, unknown>[]) ?? [])
+        processGeometry(g);
+    } else {
+      collectCoords(geom.coordinates, coords);
+    }
+  };
+
+  if (geojson.type === "FeatureCollection") {
+    for (const f of (geojson.features as { geometry: Record<string, unknown> }[]) ?? [])
+      if (f.geometry) processGeometry(f.geometry);
+  } else if (geojson.type === "Feature") {
+    const g = geojson.geometry as Record<string, unknown>;
+    if (g) processGeometry(g);
+  } else {
+    processGeometry(geojson);
+  }
+
+  if (!coords.length) return null;
+  let minLng = Infinity, minLat = Infinity, maxLng = -Infinity, maxLat = -Infinity;
+  for (const [lng, lat] of coords) {
+    if (lng < minLng) minLng = lng;
+    if (lat < minLat) minLat = lat;
+    if (lng > maxLng) maxLng = lng;
+    if (lat > maxLat) maxLat = lat;
+  }
+  return [minLng, minLat, maxLng, maxLat];
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -53,3 +53,10 @@ export function truncateAddress(address: string): string {
   if (!address) return "";
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
 }
+
+export const resolveLayerUrl = (endpoint: string): string => {
+  if (endpoint.startsWith("http://") || endpoint.startsWith("https://")) {
+    return endpoint;
+  }
+  return `${process.env.NEXT_PUBLIC_AWS_STORAGE}/${endpoint}`;
+};


### PR DESCRIPTION
## Summary

- Adds `resolveLayerUrl()` helper to `src/lib/utils.ts` that returns a full URL as-is, or prepends `NEXT_PUBLIC_AWS_STORAGE` for relative paths
- Updates all 5 places that blindly prepended the old bucket URL (`raster.ts`, `chloropleth.ts`, `line.ts`, `points.ts`, `LayersOverlay/index.tsx`)
- Updated the Parque das Tribos ATProto layer record `uri` from the wrong `${process.env.TITILER_ENDPOINT}/drone/...` placeholder to the correct full URL: `https://xprize-finals.s3.eu-west-3.amazonaws.com/drone/parque-das-tribos/2024-02-06/orthophoto.tif`

## Test plan

- [ ] Navigate to the Parque das Tribos project and enable the "Orthomosaic Parque das Tribos (Feb 2024)" layer — drone imagery should now render on the map
- [ ] Verify "Zoom to layer" button flies the map to the correct location
- [ ] Confirm existing layers on other projects (GeoJSON, choropleth, etc.) still load correctly