### PR TITLE
ECO-592 Support Bumicerts timeline layer bridge

### DIFF
--- a/src/app/(map-routes)/(main)/_components/LayersOverlay/index.tsx
+++ b/src/app/(map-routes)/(main)/_components/LayersOverlay/index.tsx
@@ -74,7 +74,7 @@ const LayersOverlay = () => {
       setMapView("project");
       if (layer.type === "raster_tif") {
         fetch(
-          `${process.env.NEXT_PUBLIC_TITILER_ENDPOINT}/cog/bounds?url=${resolveLayerUrl(layer.endpoint)}`
+          `${process.env.NEXT_PUBLIC_TITILER_ENDPOINT}/cog/bounds?url=${encodeURIComponent(resolveLayerUrl(layer.endpoint))}`
         )
           .then((r) => r.json())
           .then((data) => {

--- a/src/app/(map-routes)/(main)/_components/Map/hooks/useHighlightedPolygon.ts
+++ b/src/app/(map-routes)/(main)/_components/Map/hooks/useHighlightedPolygon.ts
@@ -2,6 +2,11 @@ import { useEffect } from "react";
 import useMapStore from "../store";
 import { GeoJSONSource } from "mapbox-gl";
 
+const EMPTY_HIGHLIGHTED_SITE: GeoJSON.FeatureCollection = {
+  type: "FeatureCollection",
+  features: [],
+};
+
 /**
  * When the active project polygon changes, fit the map to the polygon and update the highlighted site source
  * @param mapRef - The ref to the map
@@ -9,15 +14,16 @@ import { GeoJSONSource } from "mapbox-gl";
 const useHighlightedPolygon = () => {
   const highlightedPolygon = useMapStore((state) => state.highlightedPolygon);
   const mapRef = useMapStore((state) => state.mapRef);
+  const mapLoaded = useMapStore((state) => state.mapLoaded);
 
   useEffect(() => {
     const map = mapRef?.current;
-    if (!map || !highlightedPolygon) return;
+    if (!mapLoaded || !map) return;
 
     (map.getSource("highlightedSite") as GeoJSONSource | undefined)?.setData(
-      highlightedPolygon
+      highlightedPolygon ?? EMPTY_HIGHLIGHTED_SITE,
     );
-  }, [mapRef, highlightedPolygon]);
+  }, [mapLoaded, mapRef, highlightedPolygon]);
 };
 
 export default useHighlightedPolygon;

--- a/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/dynamic-layers/raster.ts
+++ b/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/dynamic-layers/raster.ts
@@ -10,7 +10,7 @@ const addRasterSourceAndLayer = async (
       map.addSource(layer.name, {
         type: "raster",
         tiles: [
-          `${process.env.NEXT_PUBLIC_TITILER_ENDPOINT}/cog/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?url=${resolveLayerUrl(layer.endpoint)}`,
+          `${process.env.NEXT_PUBLIC_TITILER_ENDPOINT}/cog/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?url=${encodeURIComponent(resolveLayerUrl(layer.endpoint))}`,
         ],
       });
     }

--- a/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/dynamic-layers/shannon-chloropleth.ts
+++ b/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/dynamic-layers/shannon-chloropleth.ts
@@ -1,11 +1,12 @@
 import { Map } from "mapbox-gl";
 import { DynamicLayer } from "@/app/(map-routes)/(main)/_components/LayersOverlay/store/types";
+import { resolveLayerUrl } from "@/lib/utils";
 
 const addShannonChoroplethSourceAndLayers = (map: Map, layer: DynamicLayer) => {
   if (!map.getSource(layer.name)) {
     map.addSource(layer.name, {
       type: "geojson",
-      data: `${process.env.NEXT_PUBLIC_AWS_STORAGE}/${layer.endpoint}`,
+      data: resolveLayerUrl(layer.endpoint),
     });
   }
 

--- a/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/measured-trees.ts
+++ b/src/app/(map-routes)/(main)/_components/Map/sources-and-layers/measured-trees.ts
@@ -6,6 +6,12 @@ import {
 import { formatOccurrenceEventDate } from "@/lib/occurrence-event-date";
 import { TreeFeature } from "../../ProjectOverlay/store/types";
 
+const selectedTreeExpression = [
+  "any",
+  ["boolean", ["feature-state", "selected"], false],
+  ["boolean", ["get", "selected"], false],
+] as const;
+
 export const treesSource: GeoJSONSourceSpecification = {
   type: "geojson",
   data: {
@@ -62,7 +68,7 @@ export const unclusteredTreesLayer: CircleLayerSpecification = {
   paint: {
     "circle-color": [
       "case",
-      ["boolean", ["feature-state", "selected"], false],
+      selectedTreeExpression,
       "#ec4899",
       ["boolean", ["feature-state", "hover"], false],
       "#0883fe",
@@ -70,7 +76,7 @@ export const unclusteredTreesLayer: CircleLayerSpecification = {
     ],
     "circle-radius": [
       "case",
-      ["boolean", ["feature-state", "selected"], false],
+      selectedTreeExpression,
       10,
       ["boolean", ["feature-state", "hover"], false],
       8,
@@ -78,13 +84,13 @@ export const unclusteredTreesLayer: CircleLayerSpecification = {
     ],
     "circle-stroke-width": [
       "case",
-      ["boolean", ["feature-state", "selected"], false],
+      selectedTreeExpression,
       3,
       1,
     ],
     "circle-stroke-color": [
       "case",
-      ["boolean", ["feature-state", "selected"], false],
+      selectedTreeExpression,
       "#ffffff",
       "#000000",
     ],

--- a/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/index.test.ts
+++ b/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/index.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it } from "vitest";
+import usePreviewStore from "../../../_features/preview/store";
+import { applyPreviewFilters, getPreviewBoundsData } from ".";
+import type { MeasuredTreesGeoJSON } from "./types";
+
+const datasetOne = "at://did:plc:org/app.gainforest.dwc.dataset/one";
+const datasetTwo = "at://did:plc:org/app.gainforest.dwc.dataset/two";
+const datasetThree = "at://did:plc:org/app.gainforest.dwc.dataset/three";
+const treeOne = "at://did:plc:org/app.gainforest.dwc.occurrence/tree-one";
+const treeTwo = "at://did:plc:org/app.gainforest.dwc.occurrence/tree-two";
+const treeThree = "at://did:plc:org/app.gainforest.dwc.occurrence/tree-three";
+
+function treeFeature(
+  id: string,
+  datasetRef: string,
+  occurrenceUri: string,
+): MeasuredTreesGeoJSON["features"][number] {
+  return {
+    id,
+    type: "Feature",
+    geometry: {
+      type: "Point",
+      coordinates: [0, 0],
+    },
+    properties: {
+      type: "measured-tree",
+      datasetRef,
+      occurrenceUri,
+    },
+  } as MeasuredTreesGeoJSON["features"][number];
+}
+
+const measuredTrees: MeasuredTreesGeoJSON = {
+  type: "FeatureCollection",
+  features: [
+    treeFeature("one", datasetOne, treeOne),
+    treeFeature("two", datasetTwo, treeTwo),
+    treeFeature("three", datasetThree, treeThree),
+  ],
+};
+
+function filteredIds(data: MeasuredTreesGeoJSON | null): string[] {
+  return data?.features.map((feature) => String(feature.id)) ?? [];
+}
+
+afterEach(() => {
+  usePreviewStore.getState().setPreviewState({
+    embedMode: false,
+    treeUri: null,
+    datasetRefs: [],
+    focusedDatasetRef: null,
+    focusedSiteRef: null,
+    previewMode: "all",
+  });
+});
+
+describe("applyPreviewFilters", () => {
+  it("keeps all trees in all mode", () => {
+    usePreviewStore.getState().setPreviewState({
+      embedMode: true,
+      treeUri: null,
+      datasetRefs: [],
+      focusedDatasetRef: null,
+      focusedSiteRef: null,
+      previewMode: "all",
+    });
+
+    expect(filteredIds(applyPreviewFilters(measuredTrees))).toEqual([
+      "one",
+      "two",
+      "three",
+    ]);
+  });
+
+  it("keeps only selected dataset refs in only mode", () => {
+    usePreviewStore.getState().setPreviewState({
+      embedMode: true,
+      treeUri: null,
+      datasetRefs: [datasetOne, datasetThree],
+      focusedDatasetRef: datasetThree,
+      focusedSiteRef: null,
+      previewMode: "only",
+    });
+
+    expect(filteredIds(applyPreviewFilters(measuredTrees))).toEqual([
+      "one",
+      "three",
+    ]);
+  });
+
+  it("clears all trees in none mode", () => {
+    usePreviewStore.getState().setPreviewState({
+      embedMode: true,
+      treeUri: null,
+      datasetRefs: [],
+      focusedDatasetRef: null,
+      focusedSiteRef: null,
+      previewMode: "none",
+    });
+
+    expect(filteredIds(applyPreviewFilters(measuredTrees))).toEqual([]);
+  });
+
+  it("uses the focused dataset when choosing preview bounds", () => {
+    usePreviewStore.getState().setPreviewState({
+      embedMode: true,
+      treeUri: null,
+      datasetRefs: [datasetOne, datasetThree],
+      focusedDatasetRef: datasetThree,
+      focusedSiteRef: null,
+      previewMode: "only",
+    });
+
+    const filteredData = applyPreviewFilters(measuredTrees);
+
+    expect(filteredIds(getPreviewBoundsData(filteredData ?? measuredTrees))).toEqual([
+      "three",
+    ]);
+  });
+
+  it("unions a selected treeUri with selected dataset refs", () => {
+    usePreviewStore.getState().setPreviewState({
+      embedMode: true,
+      treeUri: treeTwo,
+      datasetRefs: [datasetOne],
+      focusedDatasetRef: datasetOne,
+      focusedSiteRef: null,
+      previewMode: "only",
+    });
+
+    expect(filteredIds(applyPreviewFilters(measuredTrees))).toEqual(["one", "two"]);
+  });
+});

--- a/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/index.test.ts
+++ b/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/index.test.ts
@@ -118,7 +118,7 @@ describe("applyPreviewFilters", () => {
     ]);
   });
 
-  it("unions a selected treeUri with selected dataset refs", () => {
+  it("unions and marks a selected treeUri with selected dataset refs", () => {
     usePreviewStore.getState().setPreviewState({
       embedMode: true,
       treeUri: treeTwo,
@@ -128,6 +128,11 @@ describe("applyPreviewFilters", () => {
       previewMode: "only",
     });
 
-    expect(filteredIds(applyPreviewFilters(measuredTrees))).toEqual(["one", "two"]);
+    const filteredData = applyPreviewFilters(measuredTrees);
+
+    expect(filteredIds(filteredData)).toEqual(["one", "two"]);
+    expect(
+      filteredData?.features.map((feature) => feature.properties.selected),
+    ).toEqual([false, true]);
   });
 });

--- a/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/index.ts
+++ b/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/index.ts
@@ -152,22 +152,65 @@ const buildCompatProject = (did: string, slug: string): Project => ({
   Wallet: null,
 });
 
-const applyPreviewFilters = (
+const emptyMeasuredTreesGeoJSON = (): MeasuredTreesGeoJSON => ({
+  type: "FeatureCollection",
+  features: [],
+});
+
+const shouldClearPreviewTrees = (): boolean => {
+  const { previewMode, treeUri } = usePreviewStore.getState();
+  return previewMode === "none" && !treeUri;
+};
+
+const getPreviewRequestSignature = (): string => {
+  const {
+    datasetRefs,
+    focusedDatasetRef,
+    focusedSiteRef,
+    previewMode,
+    treeUri,
+  } = usePreviewStore.getState();
+  return JSON.stringify({
+    datasetRefs,
+    focusedDatasetRef,
+    focusedSiteRef,
+    previewMode,
+    treeUri,
+  });
+};
+
+const isPreviewRequestCurrent = (signature: string): boolean =>
+  signature === getPreviewRequestSignature();
+
+export const applyPreviewFilters = (
   data: MeasuredTreesGeoJSON | null,
 ): MeasuredTreesGeoJSON | null => {
   if (!data) {
-    return null;
+    return shouldClearPreviewTrees() ? emptyMeasuredTreesGeoJSON() : null;
   }
 
-  const { datasetRef, treeUri } = usePreviewStore.getState();
+  const { datasetRefs, previewMode, treeUri } = usePreviewStore.getState();
 
-  if (!datasetRef && !treeUri) {
+  if (previewMode === "all" && !treeUri) {
     return data;
   }
 
-  const datasetFiltered = datasetRef
-    ? data.features.filter((feature) => feature.properties.datasetRef === datasetRef)
-    : data.features;
+  if (previewMode === "none" && !treeUri) {
+    return {
+      ...data,
+      features: [],
+    };
+  }
+
+  const datasetRefSet = new Set(datasetRefs);
+  const datasetFiltered = previewMode === "only"
+    ? data.features.filter((feature) => {
+        const datasetRef = feature.properties.datasetRef;
+        return typeof datasetRef === "string" && datasetRefSet.has(datasetRef);
+      })
+    : previewMode === "all"
+      ? data.features
+      : [];
 
   const treeFiltered = treeUri
     ? data.features.filter((feature) => feature.properties.occurrenceUri === treeUri)
@@ -181,19 +224,30 @@ const applyPreviewFilters = (
     featureMap.set(feature.id, feature);
   }
 
-  const features = [...featureMap.values()];
-
-  if (datasetRef && features.length === 0) {
-    return {
-      ...data,
-      features: treeFiltered,
-    };
-  }
-
   return {
     ...data,
-    features,
+    features: [...featureMap.values()],
   };
+};
+
+export const getPreviewBoundsData = (
+  data: MeasuredTreesGeoJSON,
+): MeasuredTreesGeoJSON => {
+  const { focusedDatasetRef, previewMode, treeUri } = usePreviewStore.getState();
+  if (treeUri || previewMode !== "only" || !focusedDatasetRef) {
+    return data;
+  }
+
+  const focusedFeatures = data.features.filter(
+    (feature) => feature.properties.datasetRef === focusedDatasetRef,
+  );
+
+  return focusedFeatures.length > 0
+    ? {
+        ...data,
+        features: focusedFeatures,
+      }
+    : data;
 };
 
 const setMapBoundsFromTrees = (data: MeasuredTreesGeoJSON | null) => {
@@ -230,8 +284,13 @@ const setMapBoundsFromTrees = (data: MeasuredTreesGeoJSON | null) => {
 };
 
 const shouldUsePreviewBounds = (): boolean => {
-  const { embedMode, datasetRef, treeUri } = usePreviewStore.getState();
-  return embedMode || datasetRef !== null || treeUri !== null;
+  const { embedMode, datasetRefs, previewMode, treeUri } = usePreviewStore.getState();
+  return (
+    embedMode ||
+    previewMode !== "all" ||
+    datasetRefs.length > 0 ||
+    treeUri !== null
+  );
 };
 
 // ---------------------------------------------------------------------------
@@ -359,9 +418,20 @@ const useProjectOverlayStore = create<
       projectId ===
       "49bbaba0d8980989ce9b3988a45c375a42206239d6bc930c2357035e670838e0";
 
+    const previewRequestSignature = getPreviewRequestSignature();
+
     try {
+      if (shouldClearPreviewTrees()) {
+        useMapStore.getState().setHighlightedPolygon(null);
+        set({ treesAsync: { _status: "success", data: emptyMeasuredTreesGeoJSON() } });
+        return;
+      }
+
       const occurrenceData = await fetchMeasuredTreeOccurrences(projectId);
-      if (!isProjectStillActive(projectId)) {
+      if (
+        !isProjectStillActive(projectId) ||
+        !isPreviewRequestCurrent(previewRequestSignature)
+      ) {
         return;
       }
 
@@ -373,13 +443,16 @@ const useProjectOverlayStore = create<
           filteredOccurrenceData &&
           (shouldUsePreviewBounds() || !shouldFitToSite)
         ) {
-          setMapBoundsFromTrees(filteredOccurrenceData);
+          setMapBoundsFromTrees(getPreviewBoundsData(filteredOccurrenceData));
         }
         return;
       }
 
       const rawData = await fetchMeasuredTreesShapefile(slug, treesRef, projectId);
-      if (!isProjectStillActive(projectId)) {
+      if (
+        !isProjectStillActive(projectId) ||
+        !isPreviewRequestCurrent(previewRequestSignature)
+      ) {
         return;
       }
 
@@ -405,11 +478,14 @@ const useProjectOverlayStore = create<
         filteredData &&
         (shouldUsePreviewBounds() || !shouldFitToSite)
       ) {
-        setMapBoundsFromTrees(filteredData);
+        setMapBoundsFromTrees(getPreviewBoundsData(filteredData));
       }
     } catch (error) {
       console.error("Error fetching measured trees", error);
-      if (!isProjectStillActive(projectId)) {
+      if (
+        !isProjectStillActive(projectId) ||
+        !isPreviewRequestCurrent(previewRequestSignature)
+      ) {
         return;
       }
       set({ treesAsync: { _status: "error", data: null } });
@@ -503,12 +579,17 @@ const useProjectOverlayStore = create<
           allSitesOptions.some((s) => s.value === currentSiteId);
 
         if (!siteStillValid) {
-          // Prefer the defaultSite record, then fall back to first option
+          const { focusedSiteRef, previewMode } = usePreviewStore.getState();
+          const focusedPreviewOption =
+            previewMode !== "none" && focusedSiteRef
+              ? allSitesOptions.find((s) => s.value === focusedSiteRef)
+              : undefined;
+          // Prefer the focused preview site, then the defaultSite record, then the first option.
           const defaultOption = defaultSiteUri
             ? allSitesOptions.find((s) => s.value === defaultSiteUri)
             : undefined;
           const siteIdToActivate =
-            defaultOption?.value ?? allSitesOptions[0].value;
+            focusedPreviewOption?.value ?? defaultOption?.value ?? allSitesOptions[0].value;
           get().setSiteId(siteIdToActivate, navigate);
         }
       } else {
@@ -549,9 +630,13 @@ const useProjectOverlayStore = create<
 
       if (selectedSite) {
         const selectedSiteId = selectedSite.uri;
+        const sitePreviewRequestSignature = getPreviewRequestSignature();
 
         fetchSiteShapefile(projectId, selectedSite.shapefile).then((data) => {
-          if (!isSiteStillActive(projectId, selectedSiteId)) {
+          if (
+            !isSiteStillActive(projectId, selectedSiteId) ||
+            !isPreviewRequestCurrent(sitePreviewRequestSignature)
+          ) {
             return;
           }
 

--- a/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/index.ts
+++ b/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/index.ts
@@ -226,7 +226,13 @@ export const applyPreviewFilters = (
 
   return {
     ...data,
-    features: [...featureMap.values()],
+    features: [...featureMap.values()].map((feature) => ({
+      ...feature,
+      properties: {
+        ...feature.properties,
+        selected: treeUri !== null && feature.properties.occurrenceUri === treeUri,
+      },
+    })),
   };
 };
 
@@ -263,7 +269,7 @@ const setMapBoundsFromTrees = (data: MeasuredTreesGeoJSON | null) => {
 
     if (selectedFeature) {
       const [lon, lat] = selectedFeature.geometry.coordinates;
-      const offset = 0.0025;
+      const offset = 0.0005;
       useMapStore.getState().setMapBounds([
         lon - offset,
         lat - offset,

--- a/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/types.ts
+++ b/src/app/(map-routes)/(main)/_components/ProjectOverlay/store/types.ts
@@ -110,6 +110,7 @@ export type TreeFeatureProperties = {
   datasetRef?: string;
   siteRef?: string;
   treeSource?: string;
+  selected?: boolean;
   Height?: string;
   height?: string;
   diameter?: string;

--- a/src/app/(map-routes)/(main)/_features/navigation/use-store-url-sync.ts
+++ b/src/app/(map-routes)/(main)/_features/navigation/use-store-url-sync.ts
@@ -1,4 +1,4 @@
-import { ReadonlyURLSearchParams } from "next/navigation";
+import type { ReadonlyURLSearchParams } from "next/navigation";
 import { useEffect } from "react";
 import useProjectOverlayStore from "../../_components/ProjectOverlay/store";
 import useOverlayTabsStore from "../../_components/Overlay/OverlayTabs/store";
@@ -8,6 +8,11 @@ import useLayersOverlayStore from "../../_components/LayersOverlay/store";
 import useSearchOverlayStore from "../../_components/SearchOverlay/store";
 import { updateDedicatedStoresFromViews } from "../../_features/navigation/utils/project";
 import useMapStore from "../../_components/Map/store";
+import {
+  normalizePreviewDatasetRefs,
+  previewDatasetRefsEqual,
+  resolvePreviewMode,
+} from "../preview/params";
 import usePreviewStore from "../preview/store";
 
 const useStoreUrlSync = (
@@ -21,16 +26,29 @@ const useStoreUrlSync = (
 
   // ⚠️⚠️⚠️ Make sure to update the dependencies, in case of changes to the props.
   useEffect(() => {
+    const datasetRefs = normalizePreviewDatasetRefs(queryParams.getAll("dataset-ref"));
     const nextPreviewState = {
       embedMode: embed,
       treeUri: queryParams.get("tree-uri"),
-      datasetRef: queryParams.get("dataset-ref"),
+      datasetRefs,
+      focusedDatasetRef: datasetRefs.length === 1 ? datasetRefs[0] : null,
+      focusedSiteRef: null,
+      previewMode: resolvePreviewMode({
+        explicitMode: queryParams.get("preview-mode"),
+        datasetRefs,
+      }),
     };
     const previousPreviewState = usePreviewStore.getState();
     const previewChanged =
       previousPreviewState.embedMode !== nextPreviewState.embedMode ||
       previousPreviewState.treeUri !== nextPreviewState.treeUri ||
-      previousPreviewState.datasetRef !== nextPreviewState.datasetRef;
+      previousPreviewState.focusedDatasetRef !== nextPreviewState.focusedDatasetRef ||
+      previousPreviewState.focusedSiteRef !== nextPreviewState.focusedSiteRef ||
+      previousPreviewState.previewMode !== nextPreviewState.previewMode ||
+      !previewDatasetRefsEqual(
+        previousPreviewState.datasetRefs,
+        nextPreviewState.datasetRefs,
+      );
 
     const navigationState = generateNavigationStateFromURL(
       projectIdParam ? `/${projectIdParam}` : "",

--- a/src/app/(map-routes)/(main)/_features/preview/messages.test.ts
+++ b/src/app/(map-routes)/(main)/_features/preview/messages.test.ts
@@ -243,6 +243,7 @@ describe("Green Globe preview messages", () => {
           type: LEGACY_GREEN_GLOBE_PREVIEW_FOCUS_TREE_MESSAGE_TYPE,
           datasetRef: datasetOne,
           treeUri: "at://did:plc:org/app.gainforest.dwc.occurrence/tree-1",
+          siteRef: siteOne,
         },
         projectDid,
       ),
@@ -253,7 +254,7 @@ describe("Green Globe preview messages", () => {
         treeUri: "at://did:plc:org/app.gainforest.dwc.occurrence/tree-1",
         datasetRefs: [datasetOne],
         focusedDatasetRef: datasetOne,
-        focusedSiteRef: null,
+        focusedSiteRef: siteOne,
         previewMode: "only",
       },
     });

--- a/src/app/(map-routes)/(main)/_features/preview/messages.test.ts
+++ b/src/app/(map-routes)/(main)/_features/preview/messages.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildGreenGlobePreviewAckMessage,
+  buildGreenGlobePreviewReadyMessage,
+  GREEN_GLOBE_PREVIEW_ACK_MESSAGE_TYPE,
+  GREEN_GLOBE_PREVIEW_READY_MESSAGE_TYPE,
+  GREEN_GLOBE_PREVIEW_SET_DATASET_LAYERS_MESSAGE_TYPE,
+  isAllowedGreenGlobePreviewParentOrigin,
+  LEGACY_GREEN_GLOBE_PREVIEW_FOCUS_TREE_MESSAGE_TYPE,
+  previewStateFromMessage,
+} from "./messages";
+
+const projectDid = "did:plc:org";
+const datasetOne = "at://did:plc:org/app.gainforest.dwc.dataset/one";
+const datasetTwo = "at://did:plc:org/app.gainforest.dwc.dataset/two";
+const siteOne = "at://did:plc:org/app.certified.location/site-one";
+const siteTwo = "at://did:plc:org/app.certified.location/site-two";
+
+const datasetLayers = [
+  {
+    datasetRef: datasetOne,
+    title: "Dataset one",
+    siteRef: { uri: siteOne, cid: "bafy-site-one" },
+  },
+  {
+    datasetRef: datasetTwo,
+    title: "Dataset two",
+    siteRef: { uri: siteTwo, cid: "bafy-site-two" },
+  },
+];
+
+describe("Green Globe preview messages", () => {
+  it("builds ready and ack messages", () => {
+    expect(buildGreenGlobePreviewReadyMessage(projectDid)).toEqual({
+      type: GREEN_GLOBE_PREVIEW_READY_MESSAGE_TYPE,
+      version: 1,
+      projectDid,
+      capabilities: [
+        "datasetRefs",
+        "previewMode",
+        "clearSelection",
+        "fitBounds",
+        "focusedDatasetRef",
+        "focusedSiteRef",
+      ],
+    });
+
+    expect(
+      buildGreenGlobePreviewAckMessage({
+        projectDid,
+        requestId: "request-1",
+        accepted: true,
+      }),
+    ).toEqual({
+      type: GREEN_GLOBE_PREVIEW_ACK_MESSAGE_TYPE,
+      version: 1,
+      projectDid,
+      requestId: "request-1",
+      accepted: true,
+    });
+  });
+
+  it("accepts dataset-layer messages for the active embed project", () => {
+    expect(
+      previewStateFromMessage(
+        {
+          type: GREEN_GLOBE_PREVIEW_SET_DATASET_LAYERS_MESSAGE_TYPE,
+          version: 1,
+          source: "bumicerts",
+          requestId: "request-1",
+          projectDid,
+          datasetLayers,
+          activeDatasetRefs: [datasetOne, `${datasetTwo}, ${datasetOne}`],
+          focusedDatasetRef: datasetTwo,
+          emptySelection: "clear",
+        },
+        projectDid,
+      ),
+    ).toEqual({
+      requestId: "request-1",
+      state: {
+        embedMode: true,
+        treeUri: null,
+        datasetRefs: [datasetOne, datasetTwo],
+        focusedDatasetRef: datasetTwo,
+        focusedSiteRef: siteTwo,
+        previewMode: "only",
+      },
+    });
+  });
+
+  it("turns empty timeline layer selections into explicit none mode", () => {
+    expect(
+      previewStateFromMessage(
+        {
+          type: GREEN_GLOBE_PREVIEW_SET_DATASET_LAYERS_MESSAGE_TYPE,
+          version: 1,
+          source: "bumicerts",
+          projectDid,
+          datasetLayers,
+          activeDatasetRefs: [],
+          emptySelection: "clear",
+        },
+        projectDid,
+      ),
+    ).toMatchObject({
+      state: {
+        datasetRefs: [],
+        focusedDatasetRef: null,
+        focusedSiteRef: null,
+        previewMode: "none",
+      },
+    });
+  });
+
+  it("rejects messages with invalid version, source, project, or refs", () => {
+    expect(
+      previewStateFromMessage(
+        {
+          type: GREEN_GLOBE_PREVIEW_SET_DATASET_LAYERS_MESSAGE_TYPE,
+          version: 2,
+          source: "bumicerts",
+          projectDid,
+          datasetLayers,
+          activeDatasetRefs: [datasetOne],
+        },
+        projectDid,
+      ),
+    ).toBeNull();
+
+    expect(
+      previewStateFromMessage(
+        {
+          type: GREEN_GLOBE_PREVIEW_SET_DATASET_LAYERS_MESSAGE_TYPE,
+          version: 1,
+          source: "other",
+          projectDid,
+          datasetLayers,
+          activeDatasetRefs: [datasetOne],
+        },
+        projectDid,
+      ),
+    ).toBeNull();
+
+    expect(
+      previewStateFromMessage(
+        {
+          type: GREEN_GLOBE_PREVIEW_SET_DATASET_LAYERS_MESSAGE_TYPE,
+          version: 1,
+          source: "bumicerts",
+          projectDid: "did:plc:other",
+          datasetLayers,
+          activeDatasetRefs: [datasetOne],
+        },
+        projectDid,
+      ),
+    ).toBeNull();
+
+    expect(
+      previewStateFromMessage(
+        {
+          type: GREEN_GLOBE_PREVIEW_SET_DATASET_LAYERS_MESSAGE_TYPE,
+          version: 1,
+          source: "bumicerts",
+          projectDid,
+          datasetLayers,
+          activeDatasetRefs: [
+            "at://did:plc:org/app.gainforest.dwc.dataset/not-in-layers",
+          ],
+        },
+        projectDid,
+      ),
+    ).toBeNull();
+
+    expect(
+      previewStateFromMessage(
+        {
+          type: GREEN_GLOBE_PREVIEW_SET_DATASET_LAYERS_MESSAGE_TYPE,
+          version: 1,
+          source: "bumicerts",
+          projectDid,
+          datasetLayers,
+          activeDatasetRefs: [datasetOne],
+          focusedDatasetRef: datasetTwo,
+        },
+        projectDid,
+      ),
+    ).toBeNull();
+  });
+
+  it("uses configured parent origins as a restrictive allowlist", () => {
+    const originalOrigins = process.env.NEXT_PUBLIC_GREEN_GLOBE_PREVIEW_PARENT_ORIGINS;
+    process.env.NEXT_PUBLIC_GREEN_GLOBE_PREVIEW_PARENT_ORIGINS =
+      "https://bumicerts.gainforest.app, https://preview.example.com/";
+
+    try {
+      expect(
+        isAllowedGreenGlobePreviewParentOrigin("https://bumicerts.gainforest.app"),
+      ).toBe(true);
+      expect(isAllowedGreenGlobePreviewParentOrigin("https://preview.example.com")).toBe(
+        true,
+      );
+      expect(isAllowedGreenGlobePreviewParentOrigin("https://random.vercel.app")).toBe(
+        false,
+      );
+      expect(isAllowedGreenGlobePreviewParentOrigin("http://localhost:3001")).toBe(
+        false,
+      );
+    } finally {
+      if (originalOrigins === undefined) {
+        delete process.env.NEXT_PUBLIC_GREEN_GLOBE_PREVIEW_PARENT_ORIGINS;
+      } else {
+        process.env.NEXT_PUBLIC_GREEN_GLOBE_PREVIEW_PARENT_ORIGINS = originalOrigins;
+      }
+    }
+  });
+
+  it("falls back to local/deploy origins when no allowlist is configured", () => {
+    const originalOrigins = process.env.NEXT_PUBLIC_GREEN_GLOBE_PREVIEW_PARENT_ORIGINS;
+    delete process.env.NEXT_PUBLIC_GREEN_GLOBE_PREVIEW_PARENT_ORIGINS;
+
+    try {
+      expect(isAllowedGreenGlobePreviewParentOrigin("http://localhost:3001")).toBe(
+        true,
+      );
+      expect(isAllowedGreenGlobePreviewParentOrigin("https://branch.vercel.app")).toBe(
+        true,
+      );
+      expect(isAllowedGreenGlobePreviewParentOrigin("https://example.com")).toBe(
+        false,
+      );
+    } finally {
+      if (originalOrigins !== undefined) {
+        process.env.NEXT_PUBLIC_GREEN_GLOBE_PREVIEW_PARENT_ORIGINS = originalOrigins;
+      }
+    }
+  });
+
+  it("supports the legacy focus-tree message", () => {
+    expect(
+      previewStateFromMessage(
+        {
+          type: LEGACY_GREEN_GLOBE_PREVIEW_FOCUS_TREE_MESSAGE_TYPE,
+          datasetRef: datasetOne,
+          treeUri: "at://did:plc:org/app.gainforest.dwc.occurrence/tree-1",
+        },
+        projectDid,
+      ),
+    ).toEqual({
+      requestId: null,
+      state: {
+        embedMode: true,
+        treeUri: "at://did:plc:org/app.gainforest.dwc.occurrence/tree-1",
+        datasetRefs: [datasetOne],
+        focusedDatasetRef: datasetOne,
+        focusedSiteRef: null,
+        previewMode: "only",
+      },
+    });
+  });
+});

--- a/src/app/(map-routes)/(main)/_features/preview/messages.ts
+++ b/src/app/(map-routes)/(main)/_features/preview/messages.ts
@@ -52,6 +52,7 @@ type TimelineDatasetLayersMessage = {
 type LegacyFocusTreeMessage = {
   type: typeof LEGACY_GREEN_GLOBE_PREVIEW_FOCUS_TREE_MESSAGE_TYPE;
   datasetRef?: unknown;
+  siteRef?: unknown;
   treeUri?: unknown;
 };
 
@@ -233,6 +234,7 @@ export function previewStateFromMessage(
     const datasetRef = stringOrNull(message.datasetRef);
     const datasetRefs = normalizePreviewDatasetRefs(datasetRef ? [datasetRef] : []);
     const treeUri = stringOrNull(message.treeUri);
+    const focusedSiteRef = stringOrNull(message.siteRef);
 
     return {
       requestId: null,
@@ -241,7 +243,7 @@ export function previewStateFromMessage(
         treeUri,
         datasetRefs,
         focusedDatasetRef: datasetRefs.length === 1 ? datasetRefs[0] : null,
-        focusedSiteRef: null,
+        focusedSiteRef,
         previewMode: datasetRefs.length > 0 ? "only" : "all",
       },
     };

--- a/src/app/(map-routes)/(main)/_features/preview/messages.ts
+++ b/src/app/(map-routes)/(main)/_features/preview/messages.ts
@@ -1,0 +1,284 @@
+import type { PreviewState } from "./store";
+import { normalizePreviewDatasetRefs } from "./params";
+
+export const GREEN_GLOBE_PREVIEW_SET_DATASET_LAYERS_MESSAGE_TYPE =
+  "gainforest.greenGlobePreview.v1.setDatasetLayers";
+export const GREEN_GLOBE_PREVIEW_READY_MESSAGE_TYPE =
+  "gainforest.greenGlobePreview.v1.ready";
+export const GREEN_GLOBE_PREVIEW_ACK_MESSAGE_TYPE =
+  "gainforest.greenGlobePreview.v1.ack";
+export const LEGACY_GREEN_GLOBE_PREVIEW_FOCUS_TREE_MESSAGE_TYPE =
+  "gainforest.greenGlobePreview.focusTree";
+
+export type GreenGlobePreviewReadyMessage = {
+  type: typeof GREEN_GLOBE_PREVIEW_READY_MESSAGE_TYPE;
+  version: 1;
+  projectDid: string;
+  capabilities: string[];
+};
+
+export type GreenGlobePreviewAckMessage = {
+  type: typeof GREEN_GLOBE_PREVIEW_ACK_MESSAGE_TYPE;
+  version: 1;
+  projectDid: string;
+  requestId: string | null;
+  accepted: boolean;
+  error?: string;
+};
+
+type TimelineDatasetLayer = {
+  datasetRef?: unknown;
+  siteRef?: unknown;
+};
+
+type NormalizedTimelineDatasetLayers = {
+  datasetRefs: string[];
+  siteRefByDatasetRef: Map<string, string>;
+};
+
+type TimelineDatasetLayersMessage = {
+  type: typeof GREEN_GLOBE_PREVIEW_SET_DATASET_LAYERS_MESSAGE_TYPE;
+  version?: unknown;
+  source?: unknown;
+  requestId?: unknown;
+  projectDid?: unknown;
+  datasetLayers?: unknown;
+  activeDatasetRefs?: unknown;
+  focusedDatasetRef?: unknown;
+  emptySelection?: unknown;
+  treeUri?: unknown;
+};
+
+type LegacyFocusTreeMessage = {
+  type: typeof LEGACY_GREEN_GLOBE_PREVIEW_FOCUS_TREE_MESSAGE_TYPE;
+  datasetRef?: unknown;
+  treeUri?: unknown;
+};
+
+type PreviewMessageParseResult = {
+  requestId: string | null;
+  state: PreviewState;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function stringArrayOrNull(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const values: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") {
+      return null;
+    }
+    values.push(item);
+  }
+
+  return values;
+}
+
+function normalizeDatasetLayers(
+  value: unknown,
+): NormalizedTimelineDatasetLayers | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const refs: string[] = [];
+  const siteRefByDatasetRef = new Map<string, string>();
+  for (const item of value) {
+    if (!isRecord(item)) {
+      return null;
+    }
+
+    const datasetRef = stringOrNull((item as TimelineDatasetLayer).datasetRef);
+    if (!datasetRef) {
+      return null;
+    }
+
+    const rawSiteRef = (item as TimelineDatasetLayer).siteRef;
+    if (rawSiteRef !== null && rawSiteRef !== undefined) {
+      if (!isRecord(rawSiteRef)) {
+        return null;
+      }
+
+      const siteRefUri = stringOrNull(rawSiteRef.uri);
+      const siteRefCid = stringOrNull(rawSiteRef.cid);
+      if (!siteRefUri || !siteRefCid) {
+        return null;
+      }
+
+      siteRefByDatasetRef.set(datasetRef, siteRefUri);
+    }
+
+    refs.push(datasetRef);
+  }
+
+  return {
+    datasetRefs: normalizePreviewDatasetRefs(refs),
+    siteRefByDatasetRef,
+  };
+}
+
+export function buildGreenGlobePreviewReadyMessage(
+  projectDid: string,
+): GreenGlobePreviewReadyMessage {
+  return {
+    type: GREEN_GLOBE_PREVIEW_READY_MESSAGE_TYPE,
+    version: 1,
+    projectDid,
+    capabilities: [
+      "datasetRefs",
+      "previewMode",
+      "clearSelection",
+      "fitBounds",
+      "focusedDatasetRef",
+      "focusedSiteRef",
+    ],
+  };
+}
+
+export function buildGreenGlobePreviewAckMessage(args: {
+  projectDid: string;
+  requestId: string | null;
+  accepted: boolean;
+  error?: string;
+}): GreenGlobePreviewAckMessage {
+  return {
+    type: GREEN_GLOBE_PREVIEW_ACK_MESSAGE_TYPE,
+    version: 1,
+    projectDid: args.projectDid,
+    requestId: args.requestId,
+    accepted: args.accepted,
+    ...(args.error ? { error: args.error } : {}),
+  };
+}
+
+export function getGreenGlobePreviewRequestId(value: unknown): string | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  return stringOrNull(value.requestId);
+}
+
+export function previewStateFromMessage(
+  value: unknown,
+  projectDid: string,
+): PreviewMessageParseResult | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  if (value.type === GREEN_GLOBE_PREVIEW_SET_DATASET_LAYERS_MESSAGE_TYPE) {
+    const message = value as TimelineDatasetLayersMessage;
+    if (
+      message.version !== 1 ||
+      message.source !== "bumicerts" ||
+      message.projectDid !== projectDid
+    ) {
+      return null;
+    }
+
+    const rawActiveDatasetRefs = stringArrayOrNull(message.activeDatasetRefs);
+    const datasetLayers = normalizeDatasetLayers(message.datasetLayers);
+    if (!rawActiveDatasetRefs || !datasetLayers) {
+      return null;
+    }
+
+    const allowedDatasetRefs = new Set(datasetLayers.datasetRefs);
+    const datasetRefs = normalizePreviewDatasetRefs(rawActiveDatasetRefs);
+    if (datasetRefs.some((datasetRef) => !allowedDatasetRefs.has(datasetRef))) {
+      return null;
+    }
+
+    const rawFocusedDatasetRef = stringOrNull(message.focusedDatasetRef);
+    if (rawFocusedDatasetRef && !datasetRefs.includes(rawFocusedDatasetRef)) {
+      return null;
+    }
+
+    const focusedDatasetRef =
+      rawFocusedDatasetRef ?? (datasetRefs.length === 1 ? datasetRefs[0] : null);
+    const focusedSiteRef = focusedDatasetRef
+      ? (datasetLayers.siteRefByDatasetRef.get(focusedDatasetRef) ?? null)
+      : null;
+    const treeUri = stringOrNull(message.treeUri);
+    const shouldClear = message.emptySelection === "clear";
+
+    return {
+      requestId: getGreenGlobePreviewRequestId(message),
+      state: {
+        embedMode: true,
+        treeUri,
+        datasetRefs,
+        focusedDatasetRef,
+        focusedSiteRef,
+        previewMode:
+          datasetRefs.length > 0 ? "only" : shouldClear ? "none" : "all",
+      },
+    };
+  }
+
+  if (value.type === LEGACY_GREEN_GLOBE_PREVIEW_FOCUS_TREE_MESSAGE_TYPE) {
+    const message = value as LegacyFocusTreeMessage;
+    const datasetRef = stringOrNull(message.datasetRef);
+    const datasetRefs = normalizePreviewDatasetRefs(datasetRef ? [datasetRef] : []);
+    const treeUri = stringOrNull(message.treeUri);
+
+    return {
+      requestId: null,
+      state: {
+        embedMode: true,
+        treeUri,
+        datasetRefs,
+        focusedDatasetRef: datasetRefs.length === 1 ? datasetRefs[0] : null,
+        focusedSiteRef: null,
+        previewMode: datasetRefs.length > 0 ? "only" : "all",
+      },
+    };
+  }
+
+  return null;
+}
+
+export function isGreenGlobePreviewSetDatasetLayersMessage(
+  value: unknown,
+): value is TimelineDatasetLayersMessage {
+  return (
+    isRecord(value) &&
+    value.type === GREEN_GLOBE_PREVIEW_SET_DATASET_LAYERS_MESSAGE_TYPE
+  );
+}
+
+export function isAllowedGreenGlobePreviewParentOrigin(origin: string): boolean {
+  const configuredOrigins =
+    process.env.NEXT_PUBLIC_GREEN_GLOBE_PREVIEW_PARENT_ORIGINS?.split(",")
+      .map((value) => value.trim().replace(/\/$/, ""))
+      .filter(Boolean) ?? [];
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins.includes(origin);
+  }
+
+  try {
+    const { hostname } = new URL(origin);
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname.endsWith(".gainforest.app") ||
+      hostname === "gainforest.app" ||
+      hostname.endsWith(".vercel.app")
+    );
+  } catch {
+    return false;
+  }
+}

--- a/src/app/(map-routes)/(main)/_features/preview/params.test.ts
+++ b/src/app/(map-routes)/(main)/_features/preview/params.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+import {
+  normalizePreviewDatasetRefs,
+  parsePreviewMode,
+  previewDatasetRefsEqual,
+  resolvePreviewMode,
+} from "./params";
+
+describe("preview dataset refs params", () => {
+  test("normalizes repeated dataset-ref params", () => {
+    expect(
+      normalizePreviewDatasetRefs([
+        "at://did:plc:test/app.gainforest.dwc.dataset/a",
+        " at://did:plc:test/app.gainforest.dwc.dataset/b ",
+        "at://did:plc:test/app.gainforest.dwc.dataset/a",
+        "",
+      ]),
+    ).toEqual([
+      "at://did:plc:test/app.gainforest.dwc.dataset/a",
+      "at://did:plc:test/app.gainforest.dwc.dataset/b",
+    ]);
+  });
+
+  test("also accepts comma-separated refs for compatibility", () => {
+    expect(normalizePreviewDatasetRefs(["a,b", " c "])).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  test("compares normalized refs in order", () => {
+    expect(previewDatasetRefsEqual(["a", "b"], ["a", "b"])).toBe(true);
+    expect(previewDatasetRefsEqual(["a", "b"], ["b", "a"])).toBe(false);
+  });
+
+  test("parses supported preview modes", () => {
+    expect(parsePreviewMode("all")).toBe("all");
+    expect(parsePreviewMode("ONLY")).toBe("only");
+    expect(parsePreviewMode(" none ")).toBe("none");
+    expect(parsePreviewMode("hidden")).toBeNull();
+    expect(parsePreviewMode(null)).toBeNull();
+  });
+
+  test("defaults dataset-ref URLs to only mode unless explicitly overridden", () => {
+    expect(resolvePreviewMode({ explicitMode: null, datasetRefs: ["a"] })).toBe(
+      "only",
+    );
+    expect(resolvePreviewMode({ explicitMode: null, datasetRefs: [] })).toBe("all");
+    expect(resolvePreviewMode({ explicitMode: "none", datasetRefs: ["a"] })).toBe(
+      "none",
+    );
+    expect(resolvePreviewMode({ explicitMode: "all", datasetRefs: ["a"] })).toBe(
+      "all",
+    );
+  });
+});

--- a/src/app/(map-routes)/(main)/_features/preview/params.ts
+++ b/src/app/(map-routes)/(main)/_features/preview/params.ts
@@ -1,0 +1,56 @@
+import type { PreviewMode } from "./store";
+
+const PREVIEW_MODES: readonly PreviewMode[] = ["all", "only", "none"];
+
+export function normalizePreviewDatasetRefs(values: readonly string[]): string[] {
+  const refs: string[] = [];
+  const seen = new Set<string>();
+
+  for (const value of values) {
+    for (const rawRef of value.split(",")) {
+      const ref = rawRef.trim();
+      if (!ref || seen.has(ref)) {
+        continue;
+      }
+
+      seen.add(ref);
+      refs.push(ref);
+    }
+  }
+
+  return refs;
+}
+
+export function parsePreviewMode(value: string | null | undefined): PreviewMode | null {
+  if (!value) {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return PREVIEW_MODES.includes(normalized as PreviewMode)
+    ? (normalized as PreviewMode)
+    : null;
+}
+
+export function resolvePreviewMode(args: {
+  explicitMode: string | null | undefined;
+  datasetRefs: readonly string[];
+}): PreviewMode {
+  const explicitMode = parsePreviewMode(args.explicitMode);
+  if (explicitMode) {
+    return explicitMode;
+  }
+
+  return args.datasetRefs.length > 0 ? "only" : "all";
+}
+
+export function previewDatasetRefsEqual(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((value, index) => value === right[index]);
+}

--- a/src/app/(map-routes)/(main)/_features/preview/store.ts
+++ b/src/app/(map-routes)/(main)/_features/preview/store.ts
@@ -1,9 +1,14 @@
 import { create } from "zustand";
 
+export type PreviewMode = "all" | "only" | "none";
+
 export type PreviewState = {
   embedMode: boolean;
   treeUri: string | null;
-  datasetRef: string | null;
+  datasetRefs: string[];
+  focusedDatasetRef: string | null;
+  focusedSiteRef: string | null;
+  previewMode: PreviewMode;
 };
 
 type PreviewActions = {
@@ -13,7 +18,10 @@ type PreviewActions = {
 const initialState: PreviewState = {
   embedMode: false,
   treeUri: null,
-  datasetRef: null,
+  datasetRefs: [],
+  focusedDatasetRef: null,
+  focusedSiteRef: null,
+  previewMode: "all",
 };
 
 const usePreviewStore = create<PreviewState & PreviewActions>((set) => ({

--- a/src/app/(map-routes)/(main)/_features/preview/use-green-globe-preview-message-bridge.ts
+++ b/src/app/(map-routes)/(main)/_features/preview/use-green-globe-preview-message-bridge.ts
@@ -1,0 +1,122 @@
+import { useEffect } from "react";
+import useProjectOverlayStore from "../../_components/ProjectOverlay/store";
+import {
+  buildGreenGlobePreviewAckMessage,
+  buildGreenGlobePreviewReadyMessage,
+  getGreenGlobePreviewRequestId,
+  isAllowedGreenGlobePreviewParentOrigin,
+  isGreenGlobePreviewSetDatasetLayersMessage,
+  previewStateFromMessage,
+} from "./messages";
+import { previewDatasetRefsEqual } from "./params";
+import usePreviewStore, { type PreviewState } from "./store";
+
+function previewStatesEqual(left: PreviewState, right: PreviewState): boolean {
+  return (
+    left.embedMode === right.embedMode &&
+    left.treeUri === right.treeUri &&
+    left.focusedDatasetRef === right.focusedDatasetRef &&
+    left.focusedSiteRef === right.focusedSiteRef &&
+    left.previewMode === right.previewMode &&
+    previewDatasetRefsEqual(left.datasetRefs, right.datasetRefs)
+  );
+}
+
+function getReferrerOrigin(): string | null {
+  if (typeof document === "undefined" || !document.referrer) {
+    return null;
+  }
+
+  try {
+    return new URL(document.referrer).origin;
+  } catch {
+    return null;
+  }
+}
+
+function postAck(
+  source: MessageEventSource | null,
+  origin: string,
+  args: {
+    projectDid: string;
+    requestId: string | null;
+    accepted: boolean;
+    error?: string;
+  },
+) {
+  if (!source || !("postMessage" in source)) {
+    return;
+  }
+
+  (source as Window).postMessage(buildGreenGlobePreviewAckMessage(args), origin);
+}
+
+export function useGreenGlobePreviewMessageBridge(projectDid: string) {
+  useEffect(() => {
+    if (typeof window === "undefined" || window.parent === window) {
+      return;
+    }
+
+    const parentOrigin = getReferrerOrigin();
+    window.parent.postMessage(
+      buildGreenGlobePreviewReadyMessage(projectDid),
+      parentOrigin ?? "*",
+    );
+
+    function handleMessage(event: MessageEvent) {
+      if (event.source !== window.parent) {
+        return;
+      }
+
+      if (!isAllowedGreenGlobePreviewParentOrigin(event.origin)) {
+        return;
+      }
+
+      const previewResult = previewStateFromMessage(event.data, projectDid);
+      if (!previewResult) {
+        if (isGreenGlobePreviewSetDatasetLayersMessage(event.data)) {
+          postAck(event.source, event.origin, {
+            projectDid,
+            requestId: getGreenGlobePreviewRequestId(event.data),
+            accepted: false,
+            error: "invalid-message",
+          });
+        }
+        return;
+      }
+
+      const previousPreviewState = usePreviewStore.getState();
+      const previewChanged = !previewStatesEqual(
+        previousPreviewState,
+        previewResult.state,
+      );
+      usePreviewStore.getState().setPreviewState(previewResult.state);
+
+      const projectStore = useProjectOverlayStore.getState();
+      const focusedSiteRef = previewResult.state.focusedSiteRef;
+      if (previewChanged && projectStore.projectId === projectDid) {
+        const shouldFocusSite =
+          previewResult.state.previewMode !== "none" &&
+          focusedSiteRef !== null &&
+          projectStore.projectDataStatus === "success" &&
+          projectStore.atprotoSites.some((site) => site.uri === focusedSiteRef);
+
+        if (shouldFocusSite && focusedSiteRef) {
+          projectStore.setSiteId(focusedSiteRef);
+          useProjectOverlayStore.getState().activateSite(true);
+        } else {
+          projectStore.refreshTrees();
+        }
+      }
+
+      postAck(event.source, event.origin, {
+        projectDid,
+        requestId: previewResult.requestId,
+        accepted: true,
+      });
+    }
+
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [projectDid]);
+}

--- a/src/app/(map-routes)/(main)/_hooks/use-organization-measured-trees.ts
+++ b/src/app/(map-routes)/(main)/_hooks/use-organization-measured-trees.ts
@@ -510,9 +510,9 @@ const buildTreeFeature = (
 export const fetchMeasuredTreeOccurrences = async (
   did: string,
 ): Promise<MeasuredTreesGeoJSON | null> => {
-  const { datasetRef, treeUri } = usePreviewStore.getState();
+  const { datasetRefs, previewMode, treeUri } = usePreviewStore.getState();
   const shouldFetchPdsPreviewOccurrences =
-    datasetRef !== null || treeUri !== null;
+    (previewMode === "only" && datasetRefs.length > 0) || treeUri !== null;
 
   // Resolve the org DID to its home PDS. Records for Bumicerts-certified orgs
   // live on PDSes other than the default (e.g. gainforest.id), so using the
@@ -664,8 +664,12 @@ export type UseOrganizationMeasuredTreesResult = {
 const useOrganizationMeasuredTrees = (
   did: string | null | undefined,
 ): UseOrganizationMeasuredTreesResult => {
+  const datasetRefs = usePreviewStore((state) => state.datasetRefs);
+  const previewMode = usePreviewStore((state) => state.previewMode);
+  const treeUri = usePreviewStore((state) => state.treeUri);
+
   const query = useQuery({
-    queryKey: ["organization-measured-trees", did],
+    queryKey: ["organization-measured-trees", did, datasetRefs, previewMode, treeUri],
     queryFn: async () => {
       if (!did) return null;
       return fetchMeasuredTreeOccurrences(did);

--- a/src/app/embed/[projectId]/page.tsx
+++ b/src/app/embed/[projectId]/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import HoveredTreeOverlay from "@/app/(map-routes)/(main)/_components/HoveredTreeOverlay";
 import Map from "@/app/(map-routes)/(main)/_components/Map";
 import useStoreUrlSync from "@/app/(map-routes)/(main)/_features/navigation/use-store-url-sync";
+import { useGreenGlobePreviewMessageBridge } from "@/app/(map-routes)/(main)/_features/preview/use-green-globe-preview-message-bridge";
 
 function EmbedProjectMap({ projectId }: { projectId: string }) {
   const queryParams = useSearchParams();
@@ -14,6 +15,7 @@ function EmbedProjectMap({ projectId }: { projectId: string }) {
     projectId: decodedProjectId,
     embed: true,
   });
+  useGreenGlobePreviewMessageBridge(decodedProjectId);
 
   return (
     <div className="relative flex h-screen w-full flex-col bg-background">


### PR DESCRIPTION
## Summary
- Add explicit Green Globe preview modes (`all`, `only`, `none`) so Bumicerts can represent all-hidden as an empty preview.
- Add the embed `postMessage` bridge for timeline dataset layer updates with ready/ack handling, strict project/origin/source validation, and focused dataset/site support.
- Preserve multi-dataset `datasetRefs` behavior while filtering active tree layers dynamically without iframe reloads.
- Clear stale highlighted site outlines when the preview is empty and focus bounds/site highlighting on the last shown dataset while keeping all active datasets visible.
- Include dynamic-layer URL handling updates: encode Titiler raster URLs and resolve Shannon choropleth layer endpoints.
- Support the Bumicerts tree-manager preview by accepting `siteRef` on legacy focus-tree messages, marking selected tree features for reliable highlighting, and tightening selected-tree bounds so individual tree markers are visible.
- Add params, message, and preview filtering tests.

## Validation
- `bun test ./src/app/\(map-routes\)/\(main\)/_features/preview/params.test.ts ./src/app/\(map-routes\)/\(main\)/_features/preview/messages.test.ts ./src/app/\(map-routes\)/\(main\)/_components/ProjectOverlay/store/index.test.ts`
- `bun test 'src/app/(map-routes)/(main)/_features/preview/messages.test.ts' 'src/app/(map-routes)/(main)/_components/ProjectOverlay/store/index.test.ts'`
- `bunx tsc --noEmit`
- `bun run lint` — passes with existing warnings only.
- `bun run lint -- --file 'src/app/(map-routes)/(main)/_components/LayersOverlay/index.tsx' --file 'src/app/(map-routes)/(main)/_components/Map/hooks/useHighlightedPolygon.ts' --file 'src/app/(map-routes)/(main)/_components/Map/sources-and-layers/dynamic-layers/raster.ts' --file 'src/app/(map-routes)/(main)/_components/Map/sources-and-layers/dynamic-layers/shannon-chloropleth.ts' --file 'src/app/(map-routes)/(main)/_components/ProjectOverlay/store/index.ts' --file 'src/app/(map-routes)/(main)/_components/ProjectOverlay/store/index.test.ts' --file 'src/app/(map-routes)/(main)/_features/navigation/use-store-url-sync.ts' --file 'src/app/(map-routes)/(main)/_features/preview/store.ts' --file 'src/app/(map-routes)/(main)/_features/preview/params.ts' --file 'src/app/(map-routes)/(main)/_features/preview/params.test.ts' --file 'src/app/(map-routes)/(main)/_features/preview/messages.ts' --file 'src/app/(map-routes)/(main)/_features/preview/messages.test.ts' --file 'src/app/(map-routes)/(main)/_features/preview/use-green-globe-preview-message-bridge.ts' --file 'src/app/(map-routes)/(main)/_hooks/use-organization-measured-trees.ts' --file 'src/app/embed/[projectId]/page.tsx'` — passes with existing LayersOverlay hook dependency warnings.
- Full pre-commit lint passed with existing warnings only.
- Local browser QA: Green Globe homepage has no page errors; iframe ready/ack smoke test returned `{ ready: true, ack: true }`.
- Manual QA with Bumicerts local tree manager: site boundaries remain visible for both reported datasets, iframe does not reload on tree selection, and selected trees zoom/highlight correctly after the ECO-589 companion update.

## Companion
- ECO-592 companion Bumicerts PR: https://github.com/GainForest/bumicerts-monorepo/pull/133
- ECO-589 companion Bumicerts PR: https://github.com/GainForest/bumicerts-monorepo/pull/139
